### PR TITLE
Add Nix flake for installation and development

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,7 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+  - package-ecosystem: "nix"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/nix-flake.yml
+++ b/.github/workflows/nix-flake.yml
@@ -11,7 +11,11 @@ permissions:
 
 jobs:
   flake-check:
-    runs-on: "macos-latest"
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, macos-13]
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     steps:
     - uses: actions/checkout@v6
@@ -23,8 +27,8 @@ jobs:
     - name: Cache Nix store
       uses: nix-community/cache-nix-action@v7
       with:
-        primary-key: nix-${{ runner.os }}-${{ hashFiles('flake.lock', 'Cargo.lock') }}
-        restore-prefixes-first-match: nix-${{ runner.os }}-
+        primary-key: nix-${{ matrix.os }}-${{ hashFiles('flake.lock', 'Cargo.lock') }}
+        restore-prefixes-first-match: nix-${{ matrix.os }}-
         gc-max-store-size-macos: 2G
         save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     - name: Flake check

--- a/.github/workflows/nix-flake.yml
+++ b/.github/workflows/nix-flake.yml
@@ -1,0 +1,31 @@
+name: Nix Flake
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "*" ]
+
+permissions:
+  contents: read
+
+jobs:
+  flake-check:
+    runs-on: "macos-latest"
+    timeout-minutes: 15
+    steps:
+    - uses: actions/checkout@v6
+    - name: Install Nix
+      uses: cachix/install-nix-action@v30
+      with:
+        extra_nix_config: |
+          experimental-features = nix-command flakes
+    - name: Cache Nix store
+      uses: nix-community/cache-nix-action@v7
+      with:
+        primary-key: nix-${{ runner.os }}-${{ hashFiles('flake.lock', 'Cargo.lock') }}
+        restore-prefixes-first-match: nix-${{ runner.os }}-
+        gc-max-store-size-macos: 2G
+        save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    - name: Flake check
+      run: nix flake check --print-build-logs

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 .DS_Store
+/result

--- a/README.md
+++ b/README.md
@@ -30,6 +30,20 @@ xattr -cr tmignore-rs
 ```
 This is not needed if you install `tmignore-rs` using `brew`.
 
+### Nix
+If you use [Nix](https://nixos.org) with flakes enabled, you can install `tmignore-rs` directly from the repository:
+```
+nix profile install github:IohannRabeson/tmignore-rs
+```
+Or run it once without installing:
+```
+nix run github:IohannRabeson/tmignore-rs -- --help
+```
+A development shell with the Rust toolchain is also available:
+```
+nix develop github:IohannRabeson/tmignore-rs
+```
+
 ## How to use it
 ### `monitor` command
 The most important command is the `monitor` command:

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1776221942,
+        "narHash": "sha256-FbQAeVNi7G4v3QCSThrSAAvzQTmrmyDLiHNPvTF2qFM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1766437c5509f444c1b15331e82b8b6a9b967000",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -65,6 +65,8 @@
         packages.default = tmignore-rs;
         packages.tmignore-rs = tmignore-rs;
 
+        checks.build = tmignore-rs;
+
         apps.default = {
           type = "app";
           program = "${tmignore-rs}/bin/tmignore-rs";

--- a/flake.nix
+++ b/flake.nix
@@ -16,12 +16,17 @@
 
         gitRev = self.rev or self.dirtyRev or "unknown";
         shortRev = builtins.substring 0 7 gitRev;
+        version = "nix-${shortRev}";
 
         tmignore-rs = pkgs.rustPlatform.buildRustPackage {
           pname = "tmignore-rs";
-          version = "0.0.0-${shortRev}";
+          inherit version;
 
           src = self;
+
+          # Matches .github/workflows/publish.yml — the profile used for
+          # end-user binaries (LTO, stripped, single codegen unit).
+          buildType = "final";
 
           cargoLock = {
             lockFile = ./Cargo.lock;
@@ -40,7 +45,7 @@
           env = {
             VERGEN_GIT_SHA = gitRev;
             VERGEN_IDEMPOTENT = "1";
-            TMIGNORE_RS_VERSION = "0.0.0-${shortRev}";
+            TMIGNORE_RS_VERSION = version;
             LIBGIT2_SYS_USE_PKG_CONFIG = "1";
           };
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,86 @@
+{
+  description = "Makes Time Machine respect .gitignore files";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachSystem [
+      "aarch64-darwin"
+      "x86_64-darwin"
+    ] (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+
+        gitRev = self.rev or self.dirtyRev or "unknown";
+        shortRev = builtins.substring 0 7 gitRev;
+
+        tmignore-rs = pkgs.rustPlatform.buildRustPackage {
+          pname = "tmignore-rs";
+          version = "0.0.0-${shortRev}";
+
+          src = self;
+
+          cargoLock = {
+            lockFile = ./Cargo.lock;
+            outputHashes = {
+              "temp-dir-builder-0.1.0" = "sha256-v5ht7KYzVXocPydik6KzqLJ9hVESh8jCdulS6eLtDjo=";
+            };
+          };
+
+          nativeBuildInputs = with pkgs; [ pkg-config ];
+          buildInputs = with pkgs; [ libgit2 zlib ];
+
+          # vergen-git2 opens `.git`, which is absent from the Nix sandbox.
+          # Pre-setting VERGEN_GIT_SHA gives vergen the value; VERGEN_IDEMPOTENT
+          # makes it degrade gracefully if anything else is missing.
+          # TMIGNORE_RS_VERSION is what src/main.rs reads for `--version`.
+          env = {
+            VERGEN_GIT_SHA = gitRev;
+            VERGEN_IDEMPOTENT = "1";
+            TMIGNORE_RS_VERSION = "0.0.0-${shortRev}";
+            LIBGIT2_SYS_USE_PKG_CONFIG = "1";
+          };
+
+          # Tests use a git-sourced dev-dep and touch $HOME / require serial
+          # execution; not sandbox-friendly.
+          doCheck = false;
+
+          meta = with pkgs.lib; {
+            description = "Makes Time Machine respect .gitignore files";
+            homepage = "https://github.com/IohannRabeson/tmignore-rs";
+            license = licenses.mit;
+            platforms = [ "aarch64-darwin" "x86_64-darwin" ];
+            mainProgram = "tmignore-rs";
+          };
+        };
+      in {
+        packages.default = tmignore-rs;
+        packages.tmignore-rs = tmignore-rs;
+
+        apps.default = {
+          type = "app";
+          program = "${tmignore-rs}/bin/tmignore-rs";
+          meta = tmignore-rs.meta;
+        };
+
+        devShells.default = pkgs.mkShell {
+          inputsFrom = [ tmignore-rs ];
+          packages = with pkgs; [
+            cargo
+            rustc
+            rust-analyzer
+            rustfmt
+            clippy
+          ];
+          env = {
+            VERGEN_IDEMPOTENT = "1";
+            RUST_BACKTRACE = "1";
+          };
+        };
+
+        formatter = pkgs.nixpkgs-fmt;
+      });
+}


### PR DESCRIPTION
Adds a flake.nix targeting aarch64-darwin and x86_64-darwin so macOS Nix users can install with `nix profile install`, run with `nix run`, and develop with `nix develop`. 

## Notes for review

A few non-obvious bits worth flagging:

- **`build.rs` / vergen-git2.** `vergen-git2` opens `.git` at build time, which is absent from
the Nix sandbox. The derivation pre-sets `VERGEN_GIT_SHA` (from `self.rev` / `self.dirtyRev`)
and `VERGEN_IDEMPOTENT=1`, which makes vergen use the provided value (or a placeholder) instead
 of failing. No source changes needed.
- **`temp-dir-builder` dev-dep.** The git-sourced dev-dependency in `Cargo.toml` is vendored
via `cargoLock.outputHashes`. If that rev ever bumps, the hash in `flake.nix` needs to be
refreshed — the Nix error message tells you exactly what to change, and the new hash can be
generated with `nix-prefetch-git`. `doCheck = false` is set so `cargo test` isn't run in the
sandbox.

## Maintainer impact

This should be low-burden:
- `flake.lock` is committed for reproducibility. It doesn't *need* periodic refreshing — stale
lockfiles still build — but `nix flake update` once in a while is usual. If you want I'd be happy to open a PR once in a while to do this.
- The `outputHashes` entry only needs updating if the `temp-dir-builder` revision is bumped. Also happy to do this when needed.
- No existing CI, build, or release path is changed.

Adding `nix flake check` to CI would catch breakage automatically, but I left that out of this
PR to keep it focused and save build minutes. Happy to follow up with a workflow if you want.

## Ai notice
I used claude to generate the code, verified manually.