### PR TITLE
Update notify to 9.0.0-rc.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,7 +56,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -67,7 +67,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -333,7 +333,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -355,7 +355,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -401,15 +401,6 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
-
-[[package]]
-name = "fsevent-sys"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "futures-core"
@@ -750,26 +741,28 @@ dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
 name = "notify"
-version = "8.2.0"
+version = "9.0.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+checksum = "b44b771d4dd781ef14c84078693e67495da6b47f609f72e8a4da8420a861240e"
 dependencies = [
  "bitflags",
  "crossbeam-channel",
- "fsevent-sys",
  "inotify",
  "kqueue",
  "libc",
  "log",
  "mio",
  "notify-types",
+ "objc2-core-foundation",
+ "objc2-core-services",
  "walkdir",
- "windows-sys 0.60.2",
+ "windows-sys",
+ "xxhash-rust",
 ]
 
 [[package]]
@@ -803,6 +796,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "objc2-core-services"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "583300ad934cba24ff5292aee751ecc070f7ca6b39a574cc21b7b5e588e06a0b"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -1510,7 +1522,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1574,86 +1586,12 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -1663,6 +1601,12 @@ checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aee1b19627c7c60102ab80d3a9cbe18de90bfe03bfa6c3715447681f0e8c8af6"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ fnmatch-regex = "0.3.0"
 humantime = "2.3.0"
 ignore = { version = "0.4.28", features = ["simd-accel"] }
 log = "0.4.30"
-notify = { version = "8.2.0", features = ["crossbeam-channel"] }
+notify = { version = "9.0.0-rc.4", features = ["crossbeam-channel"] }
 oslog = "0.2.0"
 regex = "1.12.3"
 rusqlite = { version = "0.39.0", features = ["chrono", "bundled"], default-features = false }

--- a/src/commands/monitor.rs
+++ b/src/commands/monitor.rs
@@ -372,7 +372,7 @@ mod monitor_details {
     use anyhow::Context;
     use crossbeam_channel::{Receiver, Sender, select};
     use log::debug;
-    use notify::{PathOp, Watcher};
+    use notify::Watcher;
 
     use super::EVENT_QUEUE_SIZE;
 
@@ -445,12 +445,10 @@ mod monitor_details {
                             if let Ok(control) = control {
                                 match control {
                                     MonitorControl::SetWatchedPaths(new_paths) => {
-                                        let _ = watcher.update_paths(
-                                            std::mem::take(&mut watched_paths)
-                                                .into_iter()
-                                                .map(PathOp::Unwatch)
-                                                .collect(),
-                                        );
+                                        for path in &watched_paths {
+                                            let _ = watcher.unwatch(&path);
+                                        }
+                                        watched_paths.clear();
                                         for path in new_paths {
                                             if let Ok(()) = watcher.watch(&path, notify::RecursiveMode::Recursive) {
                                                 watched_paths.insert(path);

--- a/src/commands/monitor.rs
+++ b/src/commands/monitor.rs
@@ -371,8 +371,8 @@ mod monitor_details {
 
     use anyhow::Context;
     use crossbeam_channel::{Receiver, Sender, select};
-    use log::{debug, warn};
-    use notify::Watcher;
+    use log::debug;
+    use notify::{PathOp, Watcher};
 
     use super::EVENT_QUEUE_SIZE;
 
@@ -445,18 +445,16 @@ mod monitor_details {
                             if let Ok(control) = control {
                                 match control {
                                     MonitorControl::SetWatchedPaths(new_paths) => {
-                                        let mut paths = watcher.paths_mut();
-                                        for path in &watched_paths {
-                                            let _ = paths.remove(path);
-                                        }
-                                        watched_paths.clear();
-                                        for path in &new_paths {
-                                            if let Ok(()) = paths.add(path, notify::RecursiveMode::Recursive) {
-                                                watched_paths.insert(path.clone());
+                                        let _ = watcher.update_paths(
+                                            std::mem::take(&mut watched_paths)
+                                                .into_iter()
+                                                .map(PathOp::Unwatch)
+                                                .collect(),
+                                        );
+                                        for path in new_paths {
+                                            if let Ok(()) = watcher.watch(&path, notify::RecursiveMode::Recursive) {
+                                                watched_paths.insert(path);
                                             }
-                                        }
-                                        if let Err(error) = paths.commit() {
-                                            warn!("Failed to commit paths to watch: {error}");
                                         }
                                     },
                                     MonitorControl::SetConfigurationFile(path) => {


### PR DESCRIPTION
Potentially closes #105 as per the analysis in https://github.com/IohannRabeson/tmignore-rs/issues/105#issuecomment-5015208093.

As previously mentioned, I fully respect your decision of avoiding RC versions in your dependencies, so I'm leaving this as draft FTR, and please feel free to close it or wait until `notify` v9 is actually released when we can then update this PR.

Currently I'm testing this build on my local machine to see if anything improves.