### PR TITLE
Optimize the case where there are a lot of cached paths

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,9 @@ jobs:
     - name: Build
       run: cargo build --all --verbose --locked --target ${{ matrix.rust-target }}
     - name: Test
-      run: cargo test --locked --target ${{ matrix.rust-target }}
+      env:
+        TMIGNORE_RS_TEST_ITERATIONS: "2"
+      run: cargo test --locked --target ${{ matrix.rust-target }} -- --include-ignored
 
   clippy:
     runs-on: "macos-latest"

--- a/README.md
+++ b/README.md
@@ -160,6 +160,27 @@ Debounce duration, a delay allowing to collect similar events and process them a
 
 # Developer documentation
 
+## Hidden options
+| Option | Default |
+| --- | --- |
+| `--config` | `~/.config/tmignore-rs/config.json` |
+| `--cache` | `~/Library/Caches/tmignore-rs/cache.db` |
+| `--legacy-config` | `~/.config/tmignore/config.json` |
+| `--legacy-cache` | `~/Library/Caches/tmignore/cache.json` |
+
+Set the legacy paths too: every command starts by importing the legacy config and cache when they exist.
+
+```
+tmignore-rs \
+  --config        /tmp/bench/config.json \
+  --cache         /tmp/bench/cache.db \
+  --legacy-config /tmp/bench/none.json \
+  --legacy-cache  /tmp/bench/none.json \
+  run --dry-run
+```
+
+`--cache` does not protect the backup exclusion list, it is system state. Use `--dry-run` for that.
+
 ## How to release
 Create a new release with a version as tag (eg: 1.2.3). This will trigger an action that will build the program and upload it as release artifacts. After that the action will update the Homebrew formula and Nix.
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -223,14 +223,11 @@ impl Cache {
 
     pub fn contains_ancestor_of(&self, path: impl AsRef<Path>) -> anyhow::Result<bool> {
         let connection = self.connection.borrow();
-        let mut stmt = connection.prepare("SELECT * FROM paths WHERE path = ?1 OR path = ?2")?;
+        let mut stmt = connection.prepare("SELECT * FROM paths WHERE path = ?")?;
         let mut current = path.as_ref().parent();
 
         while let Some(ancestor) = current {
-            let exact = path_to_bytes(ancestor);
-            let mut with_separator = exact.to_vec();
-            with_separator.push(b'/');
-            if stmt.exists(params![exact, with_separator])? {
+            if stmt.exists(params![path_to_bytes(ancestor)])? {
                 return Ok(true);
             }
             current = ancestor.parent();
@@ -512,21 +509,6 @@ pub(crate) mod tests {
         cache
             .reset(owned("/repo", ["/repo/target", "/repo/a"]))
             .unwrap();
-
-        assert_eq!(expected, cache.contains_ancestor_of(path).unwrap());
-    }
-
-    #[rstest]
-    #[case("/repo/target/debug/binary", true)]
-    #[case("/repo/target/file", true)]
-    #[case("/repo/target", false)]
-    #[case("/repo/src/main.rs", false)]
-    fn test_contains_ancestor_of_directory_stored_with_trailing_separator(
-        #[case] path: &str,
-        #[case] expected: bool,
-    ) {
-        let mut cache = Cache::open_in_memory().unwrap();
-        cache.reset(owned("/repo", ["/repo/target/"])).unwrap();
 
         assert_eq!(expected, cache.contains_ancestor_of(path).unwrap());
     }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -11,7 +11,7 @@ use log::{debug, info};
 use rusqlite::{Connection, Row, Transaction, params};
 use rusqlite_migration::{M, Migrations};
 
-use crate::diff::Diff;
+use crate::diff::{Diff, Exclusion};
 
 /// The cache stores the list of paths to exclude from Time Machine backup.
 /// I refer to it by "the exclusion list" in the public documentation.
@@ -38,30 +38,10 @@ fn path_to_bytes(path: &Path) -> &[u8] {
     path.as_os_str().as_bytes()
 }
 
-struct DirectoryPrefixBounds {
-    exact: Vec<u8>,
-    lower: Vec<u8>,
-    upper: Vec<u8>,
-}
-
-impl DirectoryPrefixBounds {
-    fn new(directory: &Path) -> Self {
-        let exact = path_to_bytes(directory).to_vec();
-        let mut lower = exact.clone();
-        lower.push(b'/');
-        let mut upper = exact.clone();
-        upper.push(b'/' + 1);
-        Self {
-            exact,
-            lower,
-            upper,
-        }
-    }
-}
-
 const MIGRATIONS_SLICE: &[M<'_>] = &[
     M::up(include_str!("sql/v0.sql")),
     M::up(include_str!("sql/v1.sql")),
+    M::up(include_str!("sql/v2.sql")),
 ];
 const MIGRATIONS: Migrations<'_> = Migrations::from_slice(MIGRATIONS_SLICE);
 
@@ -148,16 +128,19 @@ impl Cache {
         Ok(())
     }
 
-    const SQL_INSERT_PATH: &str = "INSERT INTO paths (path) VALUES (?)";
+    const SQL_INSERT_PATH: &str = "INSERT INTO paths (path, repository) VALUES (?, ?)";
     const SQL_SET_LAST_UPDATE: &str = "UPDATE metadata SET last_update=?";
 
-    pub fn reset(&mut self, iter: impl IntoIterator<Item = PathBuf>) -> anyhow::Result<()> {
+    pub fn reset(&mut self, iter: impl IntoIterator<Item = Exclusion>) -> anyhow::Result<()> {
         let mut connection = self.connection.borrow_mut();
         let mut transaction = connection.transaction()?;
         let mut insert_stmt = transaction.prepare(Self::SQL_INSERT_PATH)?;
         transaction.execute("DELETE FROM paths", params![])?;
-        for path in iter {
-            insert_stmt.execute(params![path_to_bytes(&path)])?;
+        for exclusion in iter {
+            insert_stmt.execute(params![
+                path_to_bytes(exclusion.path()),
+                exclusion.repository().map(path_to_bytes)
+            ])?;
         }
         drop(insert_stmt);
         Self::set_last_update_transaction(&mut transaction)?;
@@ -173,12 +156,15 @@ impl Cache {
         Ok(())
     }
 
-    pub fn add_paths(&mut self, iter: impl Iterator<Item = PathBuf>) -> anyhow::Result<()> {
+    pub fn add_paths(&mut self, iter: impl Iterator<Item = Exclusion>) -> anyhow::Result<()> {
         let mut connection = self.connection.borrow_mut();
         let mut transaction = connection.transaction()?;
         let mut insert_stmt = transaction.prepare(Self::SQL_INSERT_PATH)?;
-        for path in iter {
-            insert_stmt.execute(params![path_to_bytes(&path)])?;
+        for exclusion in iter {
+            insert_stmt.execute(params![
+                path_to_bytes(exclusion.path()),
+                exclusion.repository().map(path_to_bytes)
+            ])?;
         }
         drop(insert_stmt);
         Self::set_last_update_transaction(&mut transaction)?;
@@ -189,13 +175,16 @@ impl Cache {
     pub fn remove_paths<'a>(
         &mut self,
         paths: impl Iterator<Item = &'a PathBuf>,
+        repository: &Path,
     ) -> anyhow::Result<()> {
+        let repository = path_to_bytes(repository);
         let mut connection = self.connection.borrow_mut();
         let mut transaction = connection.transaction()?;
         {
-            let mut delete_stmt = transaction.prepare("DELETE FROM paths WHERE path = ?")?;
+            let mut delete_stmt =
+                transaction.prepare("DELETE FROM paths WHERE path = ? AND repository = ?")?;
             for path in paths {
-                delete_stmt.execute(params![path_to_bytes(path)])?;
+                delete_stmt.execute(params![path_to_bytes(path), repository])?;
             }
         }
         Self::set_last_update_transaction(&mut transaction)?;
@@ -203,26 +192,22 @@ impl Cache {
         Ok(())
     }
 
-    pub fn paths_with_prefix(&self, directory: impl AsRef<Path>) -> anyhow::Result<Vec<PathBuf>> {
-        let directory = directory.as_ref();
-        let bounds = DirectoryPrefixBounds::new(directory);
+    pub fn paths_created_by(&self, repository: impl AsRef<Path>) -> anyhow::Result<Vec<PathBuf>> {
         let connection = self.connection.borrow();
-        let mut select_stmt = connection
-            .prepare("SELECT path FROM paths WHERE path = ?1 OR (path >= ?2 AND path < ?3)")?;
-        let paths =
-            select_stmt.query_map(params![bounds.exact, bounds.lower, bounds.upper], |row| {
-                let bytes: Vec<u8> = row.get(0)?;
+        let mut select_stmt = connection.prepare("SELECT path FROM paths WHERE repository = ?")?;
+        let paths = select_stmt.query_map(params![path_to_bytes(repository.as_ref())], |row| {
+            let bytes: Vec<u8> = row.get(0)?;
 
-                Ok(PathBuf::from(OsStr::from_bytes(&bytes)))
-            })?;
+            Ok(PathBuf::from(OsStr::from_bytes(&bytes)))
+        })?;
 
         Ok(paths.filter_map(Result::ok).collect())
     }
 
-    /// `exclusions` must already be sorted: this uses `binary_search` against it.
-    pub fn find_diff(&self, exclusions: &[PathBuf]) -> anyhow::Result<Diff> {
+    /// `exclusions` must already be sorted by path: this uses `binary_search` against it.
+    pub fn find_diff(&self, exclusions: &[Exclusion]) -> anyhow::Result<Diff> {
         let connection = self.connection.borrow();
-        let mut select_stmt = connection.prepare("SELECT path FROM paths")?;
+        let mut select_stmt = connection.prepare("SELECT DISTINCT path FROM paths")?;
         let mut cached_paths: Vec<PathBuf> = select_stmt
             .query_map(params![], |row| {
                 let bytes: Vec<u8> = row.get(0)?;
@@ -256,7 +241,7 @@ impl Cache {
 
     pub fn paths(&self) -> anyhow::Result<Vec<PathBuf>> {
         let connection = self.connection.borrow();
-        let mut stmt = connection.prepare("SELECT path FROM paths")?;
+        let mut stmt = connection.prepare("SELECT DISTINCT path FROM paths")?;
         let paths = stmt.query_map(params![], |row| {
             let bytes: Vec<u8> = row.get(0)?;
 
@@ -290,15 +275,49 @@ impl Cache {
 }
 
 #[cfg(test)]
-mod tests {
-    use std::{assert_matches, collections::BTreeSet, path::PathBuf};
+pub(crate) mod tests {
+    use std::{
+        assert_matches,
+        collections::BTreeSet,
+        path::{Path, PathBuf},
+    };
 
     use rstest::rstest;
     use temp_dir_builder::TempDirectoryBuilder;
 
-    use crate::cache::{MIGRATIONS_SLICE, OpenOrCreateError};
+    use crate::{
+        cache::{MIGRATIONS_SLICE, OpenOrCreateError},
+        diff::Exclusion,
+    };
 
     use super::Cache;
+
+    pub(crate) fn write_version_1_cache(cache_file_path: &Path, paths: &[PathBuf]) {
+        let connection = rusqlite::Connection::open(cache_file_path).unwrap();
+        connection
+            .execute_batch(include_str!("sql/v0.sql"))
+            .unwrap();
+        connection
+            .execute_batch(include_str!("sql/v1.sql"))
+            .unwrap();
+        connection.pragma_update(None, "user_version", 2).unwrap();
+        let mut insert_stmt = connection
+            .prepare("INSERT INTO paths (path) VALUES (?)")
+            .unwrap();
+        for path in paths {
+            insert_stmt
+                .execute(super::params![super::path_to_bytes(path)])
+                .unwrap();
+        }
+    }
+
+    fn orphans<const N: usize>(paths: [&str; N]) -> [Exclusion; N] {
+        paths.map(|path| Exclusion::orphan(PathBuf::from(path)))
+    }
+
+    fn owned<const N: usize>(repository: &str, paths: [&str; N]) -> [Exclusion; N] {
+        paths.map(|path| Exclusion::new(PathBuf::from(path), PathBuf::from(repository)))
+    }
 
     #[test]
     fn test_migrations() {
@@ -321,11 +340,11 @@ mod tests {
         let mut cache = Cache::open_in_memory().unwrap();
         assert!(cache.last_update().unwrap().is_none());
 
-        cache.reset([PathBuf::from("hello")]).unwrap();
+        cache.reset(orphans(["hello"])).unwrap();
         let first_update = cache.last_update().unwrap().unwrap();
 
         std::thread::sleep(std::time::Duration::from_millis(10));
-        cache.reset([PathBuf::from("world")]).unwrap();
+        cache.reset(orphans(["world"])).unwrap();
         let second_update = cache.last_update().unwrap().unwrap();
 
         assert!(second_update > first_update);
@@ -336,15 +355,11 @@ mod tests {
         let mut cache = Cache::open_in_memory().unwrap();
         assert!(cache.last_update().unwrap().is_none());
 
-        cache
-            .add_paths([PathBuf::from("hello")].into_iter())
-            .unwrap();
+        cache.add_paths(orphans(["hello"]).into_iter()).unwrap();
         let first_update = cache.last_update().unwrap().unwrap();
 
         std::thread::sleep(std::time::Duration::from_millis(10));
-        cache
-            .add_paths([PathBuf::from("world")].into_iter())
-            .unwrap();
+        cache.add_paths(orphans(["world"]).into_iter()).unwrap();
         let second_update = cache.last_update().unwrap().unwrap();
 
         assert!(second_update > first_update);
@@ -355,11 +370,15 @@ mod tests {
         let mut cache = Cache::open_in_memory().unwrap();
         assert!(cache.last_update().unwrap().is_none());
 
-        cache.remove_paths([PathBuf::from("hello")].iter()).unwrap();
+        cache
+            .remove_paths([PathBuf::from("hello")].iter(), Path::new("/repo"))
+            .unwrap();
         let first_update = cache.last_update().unwrap().unwrap();
 
         std::thread::sleep(std::time::Duration::from_millis(10));
-        cache.remove_paths([PathBuf::from("world")].iter()).unwrap();
+        cache
+            .remove_paths([PathBuf::from("world")].iter(), Path::new("/repo"))
+            .unwrap();
         let second_update = cache.last_update().unwrap().unwrap();
 
         assert!(second_update > first_update);
@@ -377,19 +396,15 @@ mod tests {
     fn test_reset() {
         let mut cache = Cache::open_in_memory().unwrap();
         assert!(cache.paths().unwrap().is_empty());
-        cache
-            .reset([PathBuf::from("hello"), PathBuf::from("world")])
-            .unwrap();
+        cache.reset(orphans(["hello", "world"])).unwrap();
         assert_eq!(2, cache.paths().unwrap().len());
     }
 
     #[test]
     fn test_find_diff() {
         let mut cache = Cache::open_in_memory().unwrap();
-        cache
-            .reset([PathBuf::from("hello"), PathBuf::from("world")])
-            .unwrap();
-        let mut exclusions = vec![PathBuf::from("world"), PathBuf::from("hey")];
+        cache.reset(orphans(["hello", "world"])).unwrap();
+        let mut exclusions = owned("/repo", ["world", "hey"]);
         exclusions.sort_unstable();
         let diff = cache.find_diff(&exclusions).unwrap();
         assert_eq!(1, diff.added.len());
@@ -399,74 +414,48 @@ mod tests {
     }
 
     #[test]
-    fn test_paths_with_prefix() {
+    fn test_paths_created_by() {
         let mut cache = Cache::open_in_memory().unwrap();
-        cache
-            .reset([
-                PathBuf::from("hello"),
-                PathBuf::from("world"),
-                PathBuf::from("1").join("a"),
-                PathBuf::from("1").join("b"),
-                PathBuf::from("1").join("c"),
-            ])
-            .unwrap();
+        let mut exclusions = owned("/repo", ["/repo/a", "/repo/b"]).to_vec();
+        exclusions.extend(owned("/repo/nested", ["/repo/nested/c"]));
+        exclusions.extend(owned("/repo-sibling", ["/repo-sibling/d"]));
+        exclusions.extend(orphans(["/repo/e"]));
+        cache.reset(exclusions).unwrap();
 
         let paths: BTreeSet<_> = cache
-            .paths_with_prefix(PathBuf::from("1"))
+            .paths_created_by("/repo")
             .unwrap()
             .into_iter()
             .collect();
 
         assert_eq!(
-            BTreeSet::from([
-                PathBuf::from("1").join("a"),
-                PathBuf::from("1").join("b"),
-                PathBuf::from("1").join("c"),
-            ]),
-            paths
+            BTreeSet::from([PathBuf::from("/repo/a"), PathBuf::from("/repo/b")]),
+            paths,
+            "only the exclusions '/repo' created must be reported: not those of the repository \
+             nested in it, not those of a repository whose path shares its prefix, and not those \
+             read from a cache written before the repository was recorded"
         );
     }
 
     #[test]
-    fn test_paths_with_prefix_does_not_include_sibling_directory() {
+    fn test_paths_created_by_reports_a_path_two_repositories_created() {
         let mut cache = Cache::open_in_memory().unwrap();
-        cache
-            .reset([
-                PathBuf::from("/repo/file"),
-                PathBuf::from("/repo-sibling/file"),
-            ])
-            .unwrap();
-
-        let paths = cache.paths_with_prefix(PathBuf::from("/repo")).unwrap();
+        let mut exclusions = owned("/repo", ["/repo/shared"]).to_vec();
+        exclusions.extend(owned("/other", ["/repo/shared"]));
+        cache.reset(exclusions).unwrap();
 
         assert_eq!(
-            vec![PathBuf::from("/repo/file")],
-            paths,
-            "/repo-sibling/file was incorrectly included in the paths for /repo"
+            vec![PathBuf::from("/repo/shared")],
+            cache.paths_created_by("/repo").unwrap()
         );
-    }
-
-    #[test]
-    fn test_paths_with_prefix_like_wildcards_and_case() {
-        let mut cache = Cache::open_in_memory().unwrap();
-
-        cache
-            .reset([
-                PathBuf::from("/Users/me/my_project/file"),
-                PathBuf::from("/Users/me/myXproject/file"),
-                PathBuf::from("/Users/me/MY_PROJECT/file"),
-            ])
-            .unwrap();
-
-        let paths = cache
-            .paths_with_prefix(PathBuf::from("/Users/me/my_project"))
-            .unwrap();
-
         assert_eq!(
-            vec![PathBuf::from("/Users/me/my_project/file")],
-            paths,
-            "'_' should not be treated as a SQL LIKE wildcard, and matching should be \
-             case-sensitive"
+            vec![PathBuf::from("/repo/shared")],
+            cache.paths_created_by("/other").unwrap()
+        );
+        assert_eq!(
+            vec![PathBuf::from("/repo/shared")],
+            cache.paths().unwrap(),
+            "a path two repositories created is one exclusion"
         );
     }
 
@@ -475,41 +464,39 @@ mod tests {
         let mut cache = Cache::open_in_memory().unwrap();
 
         cache
-            .reset([
-                PathBuf::from("hello").join("removed"),
-                PathBuf::from("world"),
-            ])
+            .reset(owned("/repo", ["/repo/removed", "/repo/kept"]))
             .unwrap();
         cache
-            .remove_paths([PathBuf::from("hello").join("removed")].iter())
+            .remove_paths([PathBuf::from("/repo/removed")].iter(), Path::new("/repo"))
             .unwrap();
 
-        assert_eq!(1, cache.paths().unwrap().len());
         assert_eq!(
-            Some(&PathBuf::from("world")),
-            cache.paths().unwrap().first()
+            vec![PathBuf::from("/repo/kept")],
+            cache.paths().unwrap(),
+            "the path that was not listed was deleted"
         );
     }
 
     #[test]
-    fn test_remove_paths_does_not_affect_paths_not_listed() {
+    fn test_remove_paths_only_removes_what_the_repository_created() {
         let mut cache = Cache::open_in_memory().unwrap();
 
+        let mut exclusions = owned("/repo", ["/repo/shared"]).to_vec();
+        exclusions.extend(owned("/other", ["/repo/shared"]));
+        cache.reset(exclusions).unwrap();
         cache
-            .reset([
-                PathBuf::from("/repo/file"),
-                PathBuf::from("/repo-sibling/file"),
-            ])
-            .unwrap();
-        cache
-            .remove_paths([PathBuf::from("/repo/file")].iter())
+            .remove_paths([PathBuf::from("/repo/shared")].iter(), Path::new("/repo"))
             .unwrap();
 
-        let paths = cache.paths().unwrap();
-        assert_eq!(1, paths.len());
         assert!(
-            paths.contains(&PathBuf::from("/repo-sibling/file")),
-            "/repo-sibling/file was incorrectly deleted"
+            cache.paths_created_by("/repo").unwrap().is_empty(),
+            "the exclusion '/repo' created was not deleted"
+        );
+        assert_eq!(
+            vec![PathBuf::from("/repo/shared")],
+            cache.paths_created_by("/other").unwrap(),
+            "removing the exclusion '/repo' created also deleted the one '/other' created for \
+             the same path"
         );
     }
 
@@ -523,7 +510,7 @@ mod tests {
     fn test_contains_ancestor_of(#[case] path: &str, #[case] expected: bool) {
         let mut cache = Cache::open_in_memory().unwrap();
         cache
-            .reset([PathBuf::from("/repo/target"), PathBuf::from("/repo/a")])
+            .reset(owned("/repo", ["/repo/target", "/repo/a"]))
             .unwrap();
 
         assert_eq!(expected, cache.contains_ancestor_of(path).unwrap());
@@ -539,9 +526,41 @@ mod tests {
         #[case] expected: bool,
     ) {
         let mut cache = Cache::open_in_memory().unwrap();
-        cache.reset([PathBuf::from("/repo/target/")]).unwrap();
+        cache.reset(owned("/repo", ["/repo/target/"])).unwrap();
 
         assert_eq!(expected, cache.contains_ancestor_of(path).unwrap());
+    }
+
+    #[test]
+    fn test_open_migrates_a_cache_written_before_the_repository_was_recorded() {
+        let temp_dir = TempDirectoryBuilder::default().build().unwrap();
+        let cache_file_path = temp_dir.path().join("cache.db");
+        write_version_1_cache(
+            &cache_file_path,
+            &[PathBuf::from("/repo/big_dir/"), PathBuf::from("/repo/a")],
+        );
+
+        let cache = Cache::open(&cache_file_path).unwrap();
+
+        assert_eq!(
+            u32::try_from(MIGRATIONS_SLICE.len()),
+            Ok(cache.get_version().unwrap())
+        );
+        assert_eq!(
+            2,
+            cache.paths().unwrap().len(),
+            "the exclusions of the previous schema must survive the migration"
+        );
+        assert!(
+            cache.paths_created_by("/repo").unwrap().is_empty(),
+            "no repository created these exclusions, so no rescan of a repository may remove them"
+        );
+        assert_eq!(
+            2,
+            cache.find_diff(&[]).unwrap().removed.len(),
+            "a full scan must still see them, otherwise an exclusion that is no longer gitignored \
+             would stay in the Time Machine exclusion list forever"
+        );
     }
 
     #[test]
@@ -567,7 +586,7 @@ mod tests {
         let cache_file_path = temp_dir.path().join("cache.db");
         {
             let mut cache = Cache::open_or_create(&cache_file_path).unwrap();
-            cache.add_paths([PathBuf::from("yo")].into_iter()).unwrap();
+            cache.add_paths(orphans(["yo"]).into_iter()).unwrap();
         }
         let cache = Cache::open_or_create(&cache_file_path).unwrap();
         let paths = cache.paths().unwrap();
@@ -581,7 +600,7 @@ mod tests {
         let cache_file_path = temp_dir.path().join("cache.db");
         let last_update_after_create = {
             let mut cache = Cache::open_or_create(&cache_file_path).unwrap();
-            cache.add_paths([PathBuf::from("yo")].into_iter()).unwrap();
+            cache.add_paths(orphans(["yo"]).into_iter()).unwrap();
             cache.last_update().unwrap()
         };
         std::thread::sleep(std::time::Duration::from_millis(10));

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,6 +1,5 @@
 use std::{
     cell::RefCell,
-    collections::BTreeSet,
     ffi::OsStr,
     os::unix::ffi::OsStrExt,
     path::{Path, PathBuf},
@@ -220,36 +219,21 @@ impl Cache {
         Ok(paths.filter_map(Result::ok).collect())
     }
 
-    pub fn find_diff(&self, exclusions: &BTreeSet<PathBuf>) -> anyhow::Result<Diff> {
-        let mut diff = Diff::default();
-
-        {
-            let connection = self.connection.borrow();
-            let mut stmt = connection.prepare("SELECT * FROM paths WHERE path = ?")?;
-            for exclusion in exclusions {
-                if !stmt.exists(params![path_to_bytes(exclusion)])? {
-                    diff.added.insert(exclusion.clone());
-                }
-            }
-        }
-
-        {
-            let connection = self.connection.borrow();
-            let mut select_stmt = connection.prepare("SELECT path FROM paths")?;
-            let paths = select_stmt.query_map(params![], |row| {
+    /// `exclusions` must already be sorted: this uses `binary_search` against it.
+    pub fn find_diff(&self, exclusions: &[PathBuf]) -> anyhow::Result<Diff> {
+        let connection = self.connection.borrow();
+        let mut select_stmt = connection.prepare("SELECT path FROM paths")?;
+        let mut cached_paths: Vec<PathBuf> = select_stmt
+            .query_map(params![], |row| {
                 let bytes: Vec<u8> = row.get(0)?;
 
                 Ok(PathBuf::from(OsStr::from_bytes(&bytes)))
-            })?;
+            })?
+            .filter_map(Result::ok)
+            .collect();
+        cached_paths.sort_unstable();
 
-            for path in paths.into_iter().filter_map(Result::ok) {
-                if !exclusions.contains(&path) {
-                    diff.removed.insert(path.clone());
-                }
-            }
-        }
-
-        Ok(diff)
+        Ok(Diff::from_sorted(exclusions, &cached_paths))
     }
 
     pub fn contains_ancestor_of(&self, path: impl AsRef<Path>) -> anyhow::Result<bool> {
@@ -402,7 +386,8 @@ mod tests {
         cache
             .reset([PathBuf::from("hello"), PathBuf::from("world")])
             .unwrap();
-        let exclusions = BTreeSet::from([PathBuf::from("world"), PathBuf::from("hey")]);
+        let mut exclusions = vec![PathBuf::from("world"), PathBuf::from("hey")];
+        exclusions.sort_unstable();
         let diff = cache.find_diff(&exclusions).unwrap();
         assert_eq!(1, diff.added.len());
         assert!(diff.added.contains(&PathBuf::from("hey")));

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -238,11 +238,14 @@ impl Cache {
 
     pub fn contains_ancestor_of(&self, path: impl AsRef<Path>) -> anyhow::Result<bool> {
         let connection = self.connection.borrow();
-        let mut stmt = connection.prepare("SELECT * FROM paths WHERE path = ?")?;
+        let mut stmt = connection.prepare("SELECT * FROM paths WHERE path = ?1 OR path = ?2")?;
         let mut current = path.as_ref().parent();
 
         while let Some(ancestor) = current {
-            if stmt.exists(params![path_to_bytes(ancestor)])? {
+            let exact = path_to_bytes(ancestor);
+            let mut with_separator = exact.to_vec();
+            with_separator.push(b'/');
+            if stmt.exists(params![exact, with_separator])? {
                 return Ok(true);
             }
             current = ancestor.parent();
@@ -522,6 +525,21 @@ mod tests {
         cache
             .reset([PathBuf::from("/repo/target"), PathBuf::from("/repo/a")])
             .unwrap();
+
+        assert_eq!(expected, cache.contains_ancestor_of(path).unwrap());
+    }
+
+    #[rstest]
+    #[case("/repo/target/debug/binary", true)]
+    #[case("/repo/target/file", true)]
+    #[case("/repo/target", false)]
+    #[case("/repo/src/main.rs", false)]
+    fn test_contains_ancestor_of_directory_stored_with_trailing_separator(
+        #[case] path: &str,
+        #[case] expected: bool,
+    ) {
+        let mut cache = Cache::open_in_memory().unwrap();
+        cache.reset([PathBuf::from("/repo/target/")]).unwrap();
 
         assert_eq!(expected, cache.contains_ancestor_of(path).unwrap());
     }

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -19,7 +19,7 @@ mod tests {
     fn test_execute() {
         let mut cache = Cache::open_in_memory().unwrap();
         cache
-            .reset([PathBuf::from("a"), PathBuf::from("b"), PathBuf::from("c")])
+            .reset(["a", "b", "c"].map(|path| crate::diff::Exclusion::orphan(PathBuf::from(path))))
             .unwrap();
         let mut writer = Vec::new();
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -46,12 +46,15 @@ fn apply_diff_and_print<TM: TimeMachineTrait>(
 ) -> HashSet<PathBuf> {
     let mut add_failed_paths = HashSet::new();
 
-    // Remove before adding: on a case insensitive filesystem a directory renamed by case only is
-    // removed under its old spelling and added under the new one, and both spellings are the same
-    // item, so adding first would let the removal undo it.
+    // On a case insensitive filesystem a directory renamed by case only is removed under its old
+    // spelling and added under the new one, and both spellings are the same item: excluding and
+    // unexcluding the same item in one pass is not applied in the order the calls are made, so the
+    // removal is dropped instead.
+    let removed = removals_to_apply(diff);
+
     let mut remove_errors = Vec::new();
     if !dry_run {
-        let mut exclusion_errors = TM::remove_exclusions(diff.removed.iter());
+        let mut exclusion_errors = TM::remove_exclusions(removed.iter().copied());
 
         remove_errors.append(&mut exclusion_errors);
     }
@@ -66,7 +69,7 @@ fn apply_diff_and_print<TM: TimeMachineTrait>(
     }
 
     let add_count = diff.added.len().saturating_sub(add_errors.len());
-    let remove_count = diff.removed.len();
+    let remove_count = removed.len();
 
     if add_count > 0 {
         info!(
@@ -95,7 +98,7 @@ fn apply_diff_and_print<TM: TimeMachineTrait>(
     }
 
     if details {
-        for path in &diff.removed {
+        for path in &removed {
             info!("- {}", path.display());
         }
     }
@@ -105,6 +108,27 @@ fn apply_diff_and_print<TM: TimeMachineTrait>(
     }
 
     add_failed_paths
+}
+
+fn removals_to_apply(diff: &crate::diff::Diff) -> Vec<&PathBuf> {
+    if diff.added.is_empty() || diff.removed.is_empty() {
+        return diff.removed.iter().collect();
+    }
+
+    let canonical_added: HashSet<PathBuf> = diff
+        .added
+        .iter()
+        .filter_map(|path| path.canonicalize().ok())
+        .collect();
+
+    diff.removed
+        .iter()
+        .filter(|path| {
+            !path
+                .canonicalize()
+                .is_ok_and(|canonical_path| canonical_added.contains(&canonical_path))
+        })
+        .collect()
 }
 
 fn create_whitelist(whitelist_patterns: &BTreeSet<String>) -> Result<RegexSet, regex::Error> {
@@ -176,6 +200,7 @@ fn join_thread<T>(thread_handle: std::thread::JoinHandle<T>) -> anyhow::Result<T
 #[cfg(test)]
 pub(crate) mod tests {
     use std::{
+        cell::RefCell,
         collections::BTreeSet,
         path::{Path, PathBuf},
         time::Duration,
@@ -333,5 +358,61 @@ pub(crate) mod tests {
             added: BTreeSet::new(),
         };
         let _ = apply_diff_and_print::<MockTimeMachineError>(&diff, false, false);
+    }
+
+    thread_local! {
+        static RECORDED_CALLS: RefCell<Vec<(&'static str, PathBuf)>> = const { RefCell::new(Vec::new()) };
+    }
+
+    struct MockTimeMachineRecorder;
+
+    impl TimeMachineTrait for MockTimeMachineRecorder {
+        fn add_exclusions<'a>(paths: impl Iterator<Item = &'a PathBuf>) -> Vec<Error> {
+            RECORDED_CALLS.with_borrow_mut(|calls| {
+                calls.extend(paths.map(|path| ("add", path.clone())));
+            });
+
+            Vec::new()
+        }
+
+        fn remove_exclusions<'a>(paths: impl Iterator<Item = &'a PathBuf>) -> Vec<Error> {
+            RECORDED_CALLS.with_borrow_mut(|calls| {
+                calls.extend(paths.map(|path| ("remove", path.clone())));
+            });
+
+            Vec::new()
+        }
+    }
+
+    #[test]
+    fn test_apply_diff_does_not_remove_an_item_it_adds_under_another_spelling() {
+        let temp_dir = TempDirectoryBuilder::default()
+            .add_empty_file("foo/a")
+            .build()
+            .unwrap();
+        let lower_case_path = temp_dir.path().join("foo");
+        let upper_case_path = temp_dir.path().join("Foo");
+
+        assert!(
+            upper_case_path.exists(),
+            "this test needs a case insensitive filesystem"
+        );
+
+        let diff = Diff {
+            added: BTreeSet::from([lower_case_path.clone()]),
+            removed: BTreeSet::from([upper_case_path]),
+        };
+
+        RECORDED_CALLS.with_borrow_mut(Vec::clear);
+
+        let error_paths = apply_diff_and_print::<MockTimeMachineRecorder>(&diff, false, false);
+
+        assert!(error_paths.is_empty());
+        assert_eq!(
+            vec![("add", lower_case_path)],
+            RECORDED_CALLS.with_borrow(Clone::clone),
+            "both spellings are the same item, so removing the old one would undo the addition of \
+             the new one"
+        );
     }
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -45,6 +45,16 @@ fn apply_diff_and_print<TM: TimeMachineTrait>(
 ) -> HashSet<PathBuf> {
     let mut add_failed_paths = HashSet::new();
 
+    // Remove before adding: on a case insensitive filesystem a directory renamed by case only is
+    // removed under its old spelling and added under the new one, and both spellings are the same
+    // item, so adding first would let the removal undo it.
+    let mut remove_errors = Vec::new();
+    if !dry_run {
+        let mut exclusion_errors = TM::remove_exclusions(diff.removed.iter());
+
+        remove_errors.append(&mut exclusion_errors);
+    }
+
     let mut add_errors = Vec::new();
     if !dry_run {
         let mut exclusion_errors = TM::add_exclusions(diff.added.iter());
@@ -52,13 +62,6 @@ fn apply_diff_and_print<TM: TimeMachineTrait>(
             add_failed_paths.insert(exclusion_error.path.clone());
         }
         add_errors.append(&mut exclusion_errors);
-    }
-
-    let mut remove_errors = Vec::new();
-    if !dry_run {
-        let mut exclusion_errors = TM::remove_exclusions(diff.removed.iter());
-
-        remove_errors.append(&mut exclusion_errors);
     }
 
     let add_count = diff.added.len().saturating_sub(add_errors.len());

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -210,12 +210,7 @@ pub(crate) mod tests {
     /// When `root_directory` is None, the temporary directory is created in `/tmp`
     /// which is excluded from Time Machine backup, meaning all children files and directories
     /// will be considered excluded from Time Machine backup anyway (`tmutil isexcluded` will always returns "[Excluded]").
-    #[allow(
-        clippy::needless_pass_by_value,
-        reason = "test-only helper always called with `&str` literals or `None`, so taking the value by reference instead would force uglier call sites (`Some(&\"literal\")`) for no real benefit"
-    )]
-    pub(crate) fn create_repository(root_directory: Option<impl AsRef<Path>>) -> TempDirectory {
-        let root_directory = root_directory.as_ref().map(std::convert::AsRef::as_ref);
+    pub(crate) fn create_repository(root_directory: Option<&Path>) -> TempDirectory {
         if let Some(root_directory) = root_directory
             && root_directory.exists()
             && root_directory.is_dir()

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -124,6 +124,9 @@ fn find_paths_to_exclude_from_backup(
     whitelist: &RegexSet,
     exclusions: &mut Vec<std::path::PathBuf>,
 ) -> anyhow::Result<()> {
+    #[cfg(test)]
+    tests::FIND_PATHS_TO_EXCLUDE_CALLS.with(|calls| calls.set(calls.get() + 1));
+
     let repository_path = repository_path.as_ref();
     let ignored_files = git::find_ignored_files(repository_path)?;
 
@@ -182,6 +185,11 @@ pub(crate) mod tests {
         diff::Diff,
         timemachine::Error,
     };
+
+    thread_local! {
+        pub(crate) static FIND_PATHS_TO_EXCLUDE_CALLS: std::cell::Cell<usize> =
+            const { std::cell::Cell::new(0) };
+    }
 
     /// Create a Git repository with some files.
     ///

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -15,6 +15,7 @@ use log::{error, info, warn};
 use regex::RegexSet;
 
 use crate::{
+    diff::Exclusion,
     git,
     timemachine::{self, Error},
 };
@@ -125,7 +126,7 @@ fn create_whitelist(whitelist_patterns: &BTreeSet<String>) -> Result<RegexSet, r
 fn find_paths_to_exclude_from_backup(
     repository_path: impl AsRef<Path>,
     whitelist: &RegexSet,
-    exclusions: &mut Vec<std::path::PathBuf>,
+    exclusions: &mut Vec<Exclusion>,
 ) -> anyhow::Result<()> {
     #[cfg(test)]
     tests::FIND_PATHS_TO_EXCLUDE_CALLS.with(|calls| calls.set(calls.get() + 1));
@@ -145,7 +146,7 @@ fn find_paths_to_exclude_from_backup(
         {
             continue;
         }
-        exclusions.push(ignored_file);
+        exclusions.push(Exclusion::new(ignored_file, repository_path.to_path_buf()));
     }
 
     Ok(())

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -193,7 +193,7 @@ pub(crate) mod tests {
 
     /// Return the path of a test directory in the crate directory, deleted first if a previous
     /// run left it behind.
-    /// 
+    ///
     /// `std::env::temp_dir` is unusable: it is excluded from Time Machine.
     pub(crate) fn prepare_test_directory(name: &str) -> PathBuf {
         let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(name);

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -191,6 +191,20 @@ pub(crate) mod tests {
             const { std::cell::Cell::new(0) };
     }
 
+    /// Return the path of a test directory in the crate directory, deleted first if a previous
+    /// run left it behind.
+    /// 
+    /// `std::env::temp_dir` is unusable: it is excluded from Time Machine.
+    pub(crate) fn prepare_test_directory(name: &str) -> PathBuf {
+        let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(name);
+
+        if path.is_dir() {
+            std::fs::remove_dir_all(&path).unwrap();
+        }
+
+        path
+    }
+
     /// Create a Git repository with some files.
     ///
     /// When `root_directory` is None, the temporary directory is created in `/tmp`

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -6,7 +6,7 @@ pub mod run;
 pub mod stats;
 
 use std::{
-    collections::BTreeSet,
+    collections::{BTreeSet, HashSet},
     path::{Path, PathBuf},
 };
 
@@ -42,8 +42,8 @@ fn apply_diff_and_print<TM: TimeMachineTrait>(
     diff: &crate::diff::Diff,
     dry_run: bool,
     details: bool,
-) -> Vec<PathBuf> {
-    let mut add_failed_paths = BTreeSet::new();
+) -> HashSet<PathBuf> {
+    let mut add_failed_paths = HashSet::new();
 
     let mut add_errors = Vec::new();
     if !dry_run {
@@ -100,7 +100,7 @@ fn apply_diff_and_print<TM: TimeMachineTrait>(
         warn!("Error: {}: {}", error.path.display(), error.message);
     }
 
-    add_errors.into_iter().map(|error| error.path).collect()
+    add_failed_paths
 }
 
 fn create_whitelist(whitelist_patterns: &BTreeSet<String>) -> Result<RegexSet, regex::Error> {
@@ -117,11 +117,12 @@ fn create_whitelist(whitelist_patterns: &BTreeSet<String>) -> Result<RegexSet, r
 
 /// Find the paths in a repository to exclude from Time Machine backup.
 /// If a path matches at least one of the regexes in the `whitelist` `RegexSet` it will not be
-/// added to the `exclusion` set.
+/// added to `exclusions`. Paths may be pushed more than once; callers that need uniqueness
+/// must dedup after collecting.
 fn find_paths_to_exclude_from_backup(
     repository_path: impl AsRef<Path>,
     whitelist: &RegexSet,
-    exclusions: &mut BTreeSet<std::path::PathBuf>,
+    exclusions: &mut Vec<std::path::PathBuf>,
 ) -> anyhow::Result<()> {
     let repository_path = repository_path.as_ref();
     let ignored_files = git::find_ignored_files(repository_path)?;
@@ -138,7 +139,7 @@ fn find_paths_to_exclude_from_backup(
         {
             continue;
         }
-        exclusions.insert(ignored_file);
+        exclusions.push(ignored_file);
     }
 
     Ok(())

--- a/src/commands/monitor.rs
+++ b/src/commands/monitor.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::BTreeSet,
+    collections::{BTreeMap, BTreeSet},
     ops::ControlFlow,
     path::{Path, PathBuf},
     thread::JoinHandle,
@@ -90,7 +90,9 @@ fn handle_event(
 
                 let mut diff = Diff::from_sorted(&exclusions, &cached_paths);
                 diff.removed.retain(|path| {
-                    crate::git::find_parent_repository(path).as_deref()
+                    path.parent()
+                        .and_then(crate::git::find_parent_repository)
+                        .as_deref()
                         == Some(repository_to_scan.as_path())
                 });
 
@@ -131,24 +133,51 @@ fn handle_event(
 
 /// Search the repositories related to some paths.
 /// The repositories listed are in one of the search directories.
-/// Paths with an ancestor already in the exclusion list are skipped: they are
-/// already excluded from backup so a new scan cannot change anything for them.
+///
+/// A path is skipped only when all three of these hold, because each one alone leaves a way for
+/// the scan of the repository to report something new:
+/// - it still exists: a path that is gone may be an exclusion to remove;
+/// - a cached exclusion already covers one of its ancestors: otherwise the path is a new entry of
+///   `git ls-files`, so a new exclusion to add;
+/// - it is ignored: a path that is not ignored stops `git ls-files --directory` from collapsing
+///   its directory, so the exclusion of that directory must be removed.
+///
+/// The repository is scanned as soon as one of its paths is not skipped.
 fn find_repositories_to_scan(
     paths: &BTreeSet<PathBuf>,
     search_directories: &BTreeSet<PathBuf>,
     cache: &Cache,
 ) -> Result<BTreeSet<PathBuf>, anyhow::Error> {
-    let mut repositories = BTreeSet::new();
+    let mut paths_by_repository: BTreeMap<PathBuf, Vec<&Path>> = BTreeMap::new();
 
     for path in paths {
-        if cache.contains_ancestor_of(path)? {
-            continue;
-        }
         if let Some(repository_path) = crate::git::find_parent_repository(path)
             && search_directories
                 .iter()
                 .any(|search_directory| repository_path.starts_with(search_directory))
         {
+            paths_by_repository
+                .entry(repository_path)
+                .or_default()
+                .push(path.as_path());
+        }
+    }
+
+    let mut repositories = BTreeSet::new();
+
+    for (repository_path, repository_paths) in paths_by_repository {
+        let mut scan = false;
+
+        for path in &repository_paths {
+            if !path.exists() || !cache.contains_ancestor_of(path)? {
+                scan = true;
+                break;
+            }
+        }
+
+        // Checking whether the paths are ignored costs a git process, so it runs once for the
+        // whole batch and only when the cheap checks did not already settle the repository.
+        if scan || crate::git::contains_not_ignored_path(&repository_path, &repository_paths)? {
             repositories.insert(repository_path);
         }
     }
@@ -1123,6 +1152,91 @@ mod tests {
 
     #[test]
     #[serial]
+    fn test_rescan_excludes_a_new_ignored_file_in_a_not_collapsed_directory() {
+        let temp_dir = TempDirectoryBuilder::default().build().unwrap();
+        let temp_dir_path = temp_dir.path().canonicalize().unwrap();
+        let main_path = temp_dir_path.join("main");
+
+        crate::commands::tests::init_git_repository(&main_path);
+        std::fs::write(main_path.join(".gitignore"), "*.log\n").unwrap();
+        let source_path = main_path.join("src");
+        std::fs::create_dir_all(&source_path).unwrap();
+        std::fs::write(source_path.join("main.rs"), "").unwrap();
+        commit_all(&main_path, "init main repository");
+
+        let mut cache = Cache::open_in_memory().unwrap();
+        let config = crate::commands::tests::create_config(&main_path);
+
+        super::super::run::execute(&config, &mut cache, false, false).unwrap();
+        assert!(
+            cache.paths().unwrap().is_empty(),
+            "the repository has nothing ignored yet"
+        );
+
+        let new_log_path = source_path.join("new.log");
+        std::fs::write(&new_log_path, "").unwrap();
+
+        let cached_paths = rescan(
+            &mut cache,
+            config,
+            &temp_dir_path,
+            BTreeSet::from([new_log_path.clone()]),
+        );
+
+        assert_eq!(
+            cached_paths,
+            BTreeSet::from([new_log_path]),
+            "'src' holds a tracked file so git does not collapse it: the new ignored file is a \
+             new entry of git ls-files and no cached exclusion covers it, so it must be excluded"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_rescan_excludes_a_new_wholly_ignored_directory() {
+        let temp_dir = TempDirectoryBuilder::default().build().unwrap();
+        let temp_dir_path = temp_dir.path().canonicalize().unwrap();
+        let main_path = temp_dir_path.join("main");
+
+        crate::commands::tests::init_git_repository(&main_path);
+        std::fs::write(main_path.join(".gitignore"), "node_modules/\n").unwrap();
+        commit_all(&main_path, "init main repository");
+
+        let mut cache = Cache::open_in_memory().unwrap();
+        let config = crate::commands::tests::create_config(&main_path);
+
+        super::super::run::execute(&config, &mut cache, false, false).unwrap();
+        assert!(
+            cache.paths().unwrap().is_empty(),
+            "'node_modules' does not exist yet"
+        );
+
+        let node_modules_path = main_path.join("node_modules");
+        std::fs::create_dir_all(&node_modules_path).unwrap();
+        std::fs::write(node_modules_path.join("a.js"), "").unwrap();
+        std::fs::write(node_modules_path.join("b.js"), "").unwrap();
+
+        let cached_paths = rescan(
+            &mut cache,
+            config,
+            &temp_dir_path,
+            BTreeSet::from([
+                node_modules_path.clone(),
+                node_modules_path.join("a.js"),
+                node_modules_path.join("b.js"),
+            ]),
+        );
+
+        assert_eq!(
+            cached_paths,
+            BTreeSet::from([node_modules_path]),
+            "every path an install creates is ignored and exists, but no cached exclusion \
+             covers them, so the new directory must be excluded"
+        );
+    }
+
+    #[test]
+    #[serial]
     fn test_rescan_removes_a_directory_exclusion_when_a_non_ignored_file_appears_in_it() {
         let temp_dir = TempDirectoryBuilder::default().build().unwrap();
         let temp_dir_path = temp_dir.path().canonicalize().unwrap();
@@ -1392,59 +1506,94 @@ mod tests {
 
     #[test]
     fn test_find_repositories_to_scan() {
-        let temp_dir = TempDirectoryBuilder::default()
-            .add_directory("repository/.git")
-            .add_directory("repository/target")
-            .add_directory("outside/.git")
-            .build()
-            .unwrap();
-        let repository_path = temp_dir.path().join("repository");
+        let temp_dir = TempDirectoryBuilder::default().build().unwrap();
+        let temp_dir_path = temp_dir.path().canonicalize().unwrap();
+        let repository_path = temp_dir_path.join("repository");
+        let outside_path = temp_dir_path.join("outside");
+
+        crate::commands::tests::init_git_repository(&repository_path);
+        crate::commands::tests::init_git_repository(&outside_path);
+        std::fs::write(repository_path.join(".gitignore"), "target\n*.log\n").unwrap();
+
+        let target_path = repository_path.join("target").join("debug");
+        std::fs::create_dir_all(&target_path).unwrap();
+        std::fs::write(target_path.join("binary"), "").unwrap();
+
+        let logs_path = repository_path.join("logs");
+        std::fs::create_dir_all(&logs_path).unwrap();
+        std::fs::write(logs_path.join("a.log"), "").unwrap();
+
+        let kept_path = logs_path.join("keep.txt");
+        std::fs::write(&kept_path, "").unwrap();
+
+        let source_path = repository_path.join("src");
+        std::fs::create_dir_all(&source_path).unwrap();
+        std::fs::write(source_path.join("main.rs"), "").unwrap();
+
+        let new_log_path = repository_path.join("new.log");
+        std::fs::write(&new_log_path, "").unwrap();
+
+        std::fs::write(outside_path.join("file"), "").unwrap();
+
         let search_directories = BTreeSet::from([repository_path.clone()]);
         let mut cache = Cache::open_in_memory().unwrap();
         cache
-            .add_paths([repository_path.join("target")].into_iter())
+            .reset([repository_path.join("target"), repository_path.join("logs")])
             .unwrap();
 
-        let repositories = super::find_repositories_to_scan(
-            &BTreeSet::from([repository_path.join("src").join("main.rs")]),
-            &search_directories,
-            &cache,
-        )
-        .unwrap();
-        assert_eq!(BTreeSet::from([repository_path.clone()]), repositories);
+        let scan = |paths: [PathBuf; 1]| {
+            super::find_repositories_to_scan(&BTreeSet::from(paths), &search_directories, &cache)
+                .unwrap()
+        };
+        let scanned = BTreeSet::from([repository_path.clone()]);
 
-        let repositories = super::find_repositories_to_scan(
-            &BTreeSet::from([repository_path.join("target").join("debug").join("bin")]),
-            &search_directories,
-            &cache,
-        )
-        .unwrap();
+        assert_eq!(scanned, scan([source_path.join("main.rs")]));
+
         assert!(
-            repositories.is_empty(),
-            "a path under an already excluded directory must not trigger a scan"
+            scan([target_path.join("binary")]).is_empty(),
+            "an ignored path a cached exclusion already covers cannot change what the scan of \
+             the repository reports"
+        );
+
+        assert!(
+            scan([logs_path.join("a.log")]).is_empty(),
+            "a directory wholly ignored stays collapsed when another ignored file changes in it"
+        );
+
+        assert_eq!(
+            scanned,
+            scan([new_log_path]),
+            "no cached exclusion covers this ignored path, so it is a new entry of git ls-files \
+             and a new exclusion to add"
+        );
+
+        assert_eq!(
+            scanned,
+            scan([kept_path.clone()]),
+            "a path that is not ignored stops the collapsing of its directory, so the exclusion \
+             of that directory must be recomputed"
+        );
+
+        assert_eq!(
+            scanned,
+            scan([target_path.join("deleted_binary")]),
+            "an ignored path that no longer exists may have been an exclusion to remove"
+        );
+
+        assert!(
+            scan([outside_path.join("file")]).is_empty(),
+            "a repository outside the search directories must not be scanned"
         );
 
         let repositories = super::find_repositories_to_scan(
-            &BTreeSet::from([repository_path.join("target")]),
+            &BTreeSet::from([logs_path.join("a.log"), kept_path]),
             &search_directories,
             &cache,
         )
         .unwrap();
         assert_eq!(
-            BTreeSet::from([repository_path.clone()]),
-            repositories,
-            "an event on the excluded directory itself must trigger a scan"
-        );
-
-        let repositories = super::find_repositories_to_scan(
-            &BTreeSet::from([temp_dir.path().join("outside").join("file")]),
-            &search_directories,
-            &cache,
-        )
-        .unwrap();
-        assert!(
-            repositories.is_empty(),
-            "a repository outside the search directories must not be scanned"
+            scanned, repositories,
+            "a single path that is not ignored is enough to scan the repository"
         );
     }
 

--- a/src/commands/monitor.rs
+++ b/src/commands/monitor.rs
@@ -872,6 +872,15 @@ mod tests {
         cached_paths
     }
 
+    fn test_iterations(default: usize) -> usize {
+        match std::env::var("TMIGNORE_RS_TEST_ITERATIONS") {
+            Ok(value) => value.parse().unwrap_or_else(|error| {
+                panic!("TMIGNORE_RS_TEST_ITERATIONS='{value}' is not a valid usize: {error}")
+            }),
+            Err(_) => default,
+        }
+    }
+
     fn commit_all(repository_path: &Path, message: &str) {
         run_git(&["-C", repository_path.to_str().unwrap(), "add", "-A"]);
         run_git(&[
@@ -1192,15 +1201,7 @@ mod tests {
         std::fs::write(deep_path.join(".keep"), "").unwrap();
         commit_all(&main_path, "add deep sentinel");
 
-        // Defaults to a genuinely large scenario for manual stress-testing/profiling;
-        // CI overrides this to a tiny value via TMIGNORE_RS_TEST_ITERATIONS, since it
-        // only needs to confirm the scenario still passes, not exercise it at scale.
-        let iterations: usize = match std::env::var("TMIGNORE_RS_TEST_ITERATIONS") {
-            Ok(value) => value.parse().unwrap_or_else(|error| {
-                panic!("TMIGNORE_RS_TEST_ITERATIONS='{value}' is not a valid usize: {error}")
-            }),
-            Err(_) => 100_000,
-        };
+        let iterations = test_iterations(100_000);
 
         let mut ignored_paths = BTreeSet::new();
         for i in 0..iterations {
@@ -1239,6 +1240,49 @@ mod tests {
             );
         }
         assert_eq!(cached_paths.len(), ignored_paths.len());
+    }
+
+    #[test]
+    #[serial]
+    #[ignore = "kept for stress-testing and manual profiling; run explicitly with `cargo test -- --ignored`"]
+    fn test_rescan_huge_ignored_tree_with_no_nested_repositories() {
+        let temp_dir = TempDirectoryBuilder::default().build().unwrap();
+        let temp_dir_path = temp_dir.path().canonicalize().unwrap();
+        let main_path = temp_dir_path.join("main");
+
+        crate::commands::tests::init_git_repository(&main_path);
+        std::fs::write(main_path.join(".gitignore"), "big_dir\n").unwrap();
+        commit_all(&main_path, "init main repository");
+
+        let big_dir = main_path.join("big_dir");
+        std::fs::create_dir_all(&big_dir).unwrap();
+        let iterations = test_iterations(200_000);
+        for i in 0..iterations {
+            std::fs::write(big_dir.join(format!("file_{i}")), "").unwrap();
+        }
+
+        let mut cache = Cache::open_in_memory().unwrap();
+        let config = crate::commands::tests::create_config(&main_path);
+
+        super::super::run::execute(&config, &mut cache, false, false).unwrap();
+
+        let cached_paths: BTreeSet<_> = cache.paths().unwrap().into_iter().collect();
+        assert_eq!(
+            cached_paths,
+            BTreeSet::from([big_dir.clone()]),
+            "git ls-files --directory collapses a wholly-ignored directory into one entry"
+        );
+
+        std::fs::write(main_path.join(".gitignore"), "big_dir\n\n").unwrap();
+
+        let cached_paths = rescan(
+            &mut cache,
+            config,
+            &temp_dir_path,
+            BTreeSet::from([main_path.join(".gitignore")]),
+        );
+
+        assert_eq!(cached_paths, BTreeSet::from([big_dir]));
     }
 
     #[test]

--- a/src/commands/monitor.rs
+++ b/src/commands/monitor.rs
@@ -176,7 +176,7 @@ fn find_repositories_to_scan(
 
         // Checking whether the paths are ignored costs a git process, so it runs once for the
         // whole batch and only when the cheap checks did not already settle the repository.
-        if scan || crate::git::contains_not_ignored_path(&repository_path, &repository_paths)? {
+        if scan || crate::git::contains_not_ignored_path(&repository_path, &repository_paths) {
             repositories.insert(repository_path);
         }
     }

--- a/src/commands/monitor.rs
+++ b/src/commands/monitor.rs
@@ -357,9 +357,12 @@ impl Monitor {
     }
 
     pub fn set_watched_paths(&mut self, paths: &BTreeSet<PathBuf>) {
-        let _ = self
-            .control_sender
-            .send(MonitorControl::SetWatchedPaths(paths.clone()));
+        let (registered_sender, registered_receiver) = crossbeam_channel::bounded(1);
+        let _ = self.control_sender.send(MonitorControl::SetWatchedPaths(
+            paths.clone(),
+            registered_sender,
+        ));
+        let _ = registered_receiver.recv();
     }
 
     pub fn set_debounce_duration(&mut self, duration: Duration) {
@@ -441,7 +444,7 @@ mod monitor_details {
     }
 
     pub enum MonitorControl {
-        SetWatchedPaths(BTreeSet<PathBuf>),
+        SetWatchedPaths(BTreeSet<PathBuf>, Sender<()>),
         SetConfigurationFile(PathBuf),
         SetGlobalGitIgnore(PathBuf),
         Shutdown,
@@ -486,7 +489,7 @@ mod monitor_details {
                         recv(control_receiver) -> control => {
                             if let Ok(control) = control {
                                 match control {
-                                    MonitorControl::SetWatchedPaths(new_paths) => {
+                                    MonitorControl::SetWatchedPaths(new_paths, registered) => {
                                         for path in &watched_paths {
                                             let _ = watcher.unwatch(path);
                                         }
@@ -496,6 +499,7 @@ mod monitor_details {
                                                 watched_paths.insert(path);
                                             }
                                         }
+                                        let _ = registered.send(());
                                     },
                                     MonitorControl::SetConfigurationFile(path) => {
                                         if let Some(configuration_file_path) = configuration_file_path.take() {
@@ -885,6 +889,40 @@ mod tests {
         drop(monitor);
 
         cached_paths
+    }
+
+    #[test]
+    #[serial]
+    fn test_set_watched_paths_registers_the_watch_before_returning() {
+        let temp_dir = TempDirectoryBuilder::default().build().unwrap();
+        let temp_dir_path = temp_dir.path().canonicalize().unwrap();
+        let mut monitor = super::Monitor::new().unwrap();
+
+        monitor.set_debounce_duration(Duration::from_millis(100));
+        monitor.set_watched_paths(&BTreeSet::from([temp_dir_path.clone()]));
+
+        let created_path = temp_dir_path.join("created");
+        std::fs::write(&created_path, "").unwrap();
+
+        // Read the channel directly instead of calling get_event because it blocks without a timeout, so
+        // a regression would hang the suite instead of failing it.
+        let event = monitor
+            .event_receiver_final
+            .recv_timeout(Duration::from_secs(10));
+
+        crate::commands::tests::send_sigint();
+        drop(monitor);
+
+        match event {
+            Ok(super::Event::ScanPaths(paths)) => assert!(
+                paths.contains(&created_path),
+                "the watcher reported an event, but not for the created path: {paths:?}"
+            ),
+            other => panic!(
+                "a path created right after set_watched_paths returned was not reported, so the \
+                 watch was not registered yet when it returned: {other:?}"
+            ),
+        }
     }
 
     fn test_iterations(default: usize) -> usize {

--- a/src/commands/monitor.rs
+++ b/src/commands/monitor.rs
@@ -132,11 +132,12 @@ fn handle_event(
 /// Search the repositories related to some paths.
 /// The repositories listed are in one of the search directories.
 ///
-/// A path is skipped only when all three of these hold, because each one alone leaves a way for
-/// the scan of the repository to report something new:
-/// - it still exists: a path that is gone may be an exclusion to remove;
+/// A path is skipped only when both of these hold, because each one alone leaves a way for the
+/// scan of the repository to report something new:
 /// - a cached exclusion already covers one of its ancestors: otherwise the path is a new entry of
-///   `git ls-files`, so a new exclusion to add;
+///   `git ls-files`, so a new exclusion to add. A path that was deleted is covered by this too:
+///   an exclusion to remove is never covered by another one, because `git ls-files --directory`
+///   collapses, so the cache never holds both a directory and something under it;
 /// - it is ignored: a path that is not ignored stops `git ls-files --directory` from collapsing
 ///   its directory, so the exclusion of that directory must be removed.
 ///
@@ -167,7 +168,7 @@ fn find_repositories_to_scan(
         let mut scan = false;
 
         for path in &repository_paths {
-            if !path.exists() || !cache.contains_ancestor_of(path)? {
+            if !cache.contains_ancestor_of(path)? {
                 scan = true;
                 break;
             }
@@ -1678,10 +1679,17 @@ mod tests {
              of that directory must be recomputed"
         );
 
+        assert!(
+            scan([target_path.join("deleted_binary")]).is_empty(),
+            "the exclusion covering this path is still there, so deleting a path under it cannot \
+             change what the scan of the repository reports"
+        );
+
         assert_eq!(
             scanned,
-            scan([target_path.join("deleted_binary")]),
-            "an ignored path that no longer exists may have been an exclusion to remove"
+            scan([repository_path.join("target")]),
+            "the deleted path is itself the cached exclusion: nothing covers it any more, so it \
+             is an exclusion to remove"
         );
 
         assert!(

--- a/src/commands/monitor.rs
+++ b/src/commands/monitor.rs
@@ -85,16 +85,10 @@ fn handle_event(
                 exclusions.sort_unstable();
                 exclusions.dedup();
 
-                let mut cached_paths = context.cache.paths_with_prefix(repository_to_scan)?;
+                let mut cached_paths = context.cache.paths_created_by(repository_to_scan)?;
                 cached_paths.sort_unstable();
 
-                let mut diff = Diff::from_sorted(&exclusions, &cached_paths);
-                diff.removed.retain(|path| {
-                    path.parent()
-                        .and_then(crate::git::find_parent_repository)
-                        .as_deref()
-                        == Some(repository_to_scan.as_path())
-                });
+                let diff = Diff::from_sorted(&exclusions, &cached_paths);
 
                 if diff.added.is_empty() && diff.removed.is_empty() {
                     debug!(
@@ -112,13 +106,17 @@ fn handle_event(
 
                 if !context.dry_run {
                     if !diff.removed.is_empty() {
-                        context.cache.remove_paths(diff.removed.iter())?;
+                        context
+                            .cache
+                            .remove_paths(diff.removed.iter(), repository_to_scan)?;
                     }
                     let paths_to_add = diff
                         .added
                         .iter()
                         .filter(|path| !paths_failed_to_add.contains(*path))
-                        .cloned();
+                        .map(|path| {
+                            crate::diff::Exclusion::new(path.clone(), repository_to_scan.clone())
+                        });
                     context.cache.add_paths(paths_to_add)?;
                 }
             }
@@ -1355,6 +1353,109 @@ mod tests {
 
     #[test]
     #[serial]
+    fn test_rescan_removes_an_exclusion_after_a_repository_appears_under_it() {
+        let temp_dir = TempDirectoryBuilder::default().build().unwrap();
+        let temp_dir_path = temp_dir.path().canonicalize().unwrap();
+        let main_path = temp_dir_path.join("main");
+
+        crate::commands::tests::init_git_repository(&main_path);
+        std::fs::write(main_path.join(".gitignore"), "vendor/thing\n").unwrap();
+        let thing_path = main_path.join("vendor").join("thing");
+        std::fs::create_dir_all(&thing_path).unwrap();
+        std::fs::write(thing_path.join("file"), "").unwrap();
+        commit_all(&main_path, "init main repository");
+
+        let mut cache = Cache::open_in_memory().unwrap();
+        let config = crate::commands::tests::create_config(&main_path);
+
+        super::super::run::execute(&config, &mut cache, false, false).unwrap();
+
+        let cached_paths: BTreeSet<_> = cache.paths().unwrap().into_iter().collect();
+        assert!(
+            cached_paths.contains(&thing_path),
+            "the initial scan should have excluded the ignored directory"
+        );
+
+        crate::commands::tests::init_git_repository(main_path.join("vendor"));
+        std::fs::write(main_path.join(".gitignore"), "\n").unwrap();
+
+        let cached_paths = rescan(
+            &mut cache,
+            config,
+            &temp_dir_path,
+            BTreeSet::from([main_path.join(".gitignore")]),
+        );
+
+        assert!(
+            !cached_paths.contains(&thing_path),
+            "the main repository created this exclusion and no longer gitignores it, so \
+             rescanning the main repository must remove it even though a repository has since \
+             appeared between it and the main repository"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_a_cache_written_before_the_repository_was_recorded_is_usable_after_a_full_scan() {
+        let temp_dir = TempDirectoryBuilder::default().build().unwrap();
+        let temp_dir_path = temp_dir.path().canonicalize().unwrap();
+        let main_path = temp_dir_path.join("main");
+
+        crate::commands::tests::init_git_repository(&main_path);
+        std::fs::write(main_path.join(".gitignore"), "a\nbig_dir\n").unwrap();
+        commit_all(&main_path, "init main repository");
+
+        let a_path = main_path.join("a");
+        let big_dir_path = main_path.join("big_dir");
+        std::fs::write(&a_path, "").unwrap();
+        std::fs::create_dir_all(&big_dir_path).unwrap();
+        std::fs::write(big_dir_path.join("b"), "").unwrap();
+
+        let cache_file_path = temp_dir_path.join("cache.db");
+        crate::cache::tests::write_version_1_cache(
+            &cache_file_path,
+            &[
+                a_path.clone(),
+                PathBuf::from(format!("{}/", big_dir_path.display())),
+            ],
+        );
+        let mut cache = Cache::open(&cache_file_path).unwrap();
+        let config = crate::commands::tests::create_config(&main_path);
+
+        assert!(
+            cache.paths_created_by(&main_path).unwrap().is_empty(),
+            "the migrated exclusions have no owner yet"
+        );
+
+        super::super::run::execute(&config, &mut cache, false, false).unwrap();
+
+        let mut owned = cache.paths_created_by(&main_path).unwrap();
+        owned.sort_unstable();
+        assert_eq!(
+            vec![a_path.clone(), big_dir_path.clone()],
+            owned,
+            "the full scan must re-attribute every exclusion to the repository that produced it"
+        );
+
+        std::fs::write(main_path.join(".gitignore"), "big_dir\n").unwrap();
+
+        let cached_paths = rescan(
+            &mut cache,
+            config,
+            &temp_dir_path,
+            BTreeSet::from([main_path.join(".gitignore")]),
+        );
+
+        assert_eq!(
+            BTreeSet::from([big_dir_path]),
+            cached_paths,
+            "'a' is no longer gitignored so the rescan must remove it, which it can only do now \
+             that the migrated rows carry an owner"
+        );
+    }
+
+    #[test]
+    #[serial]
     fn test_rescan_large_ignored_tree_preserves_exclusions() {
         let temp_dir = TempDirectoryBuilder::default().build().unwrap();
         let temp_dir_path = temp_dir.path().canonicalize().unwrap();
@@ -1538,7 +1639,10 @@ mod tests {
         let search_directories = BTreeSet::from([repository_path.clone()]);
         let mut cache = Cache::open_in_memory().unwrap();
         cache
-            .reset([repository_path.join("target"), repository_path.join("logs")])
+            .reset(
+                [repository_path.join("target"), repository_path.join("logs")]
+                    .map(|path| crate::diff::Exclusion::new(path, repository_path.clone())),
+            )
             .unwrap();
 
         let scan = |paths: [PathBuf; 1]| {

--- a/src/commands/monitor.rs
+++ b/src/commands/monitor.rs
@@ -409,6 +409,7 @@ fn log_status(status: anyhow::Result<bool>) -> bool {
 mod monitor_details {
     use std::{
         collections::BTreeSet,
+        ops::ControlFlow,
         path::PathBuf,
         thread::JoinHandle,
         time::{Duration, Instant},
@@ -450,75 +451,124 @@ mod monitor_details {
         Shutdown,
     }
 
+    struct MonitorState {
+        watcher: notify::RecommendedWatcher,
+        watched_paths: BTreeSet<PathBuf>,
+        configuration_file_path: Option<PathBuf>,
+        global_gitignore: Option<PathBuf>,
+    }
+
+    impl MonitorState {
+        fn handle_control(&mut self, control: MonitorControl) -> ControlFlow<()> {
+            match control {
+                MonitorControl::SetWatchedPaths(new_paths, registered) => {
+                    for path in &self.watched_paths {
+                        let _ = self.watcher.unwatch(path);
+                    }
+                    self.watched_paths.clear();
+                    for path in new_paths {
+                        if let Ok(()) = self.watcher.watch(&path, notify::RecursiveMode::Recursive)
+                        {
+                            self.watched_paths.insert(path);
+                        }
+                    }
+                    let _ = registered.send(());
+                }
+                MonitorControl::SetConfigurationFile(path) => {
+                    if let Some(configuration_file_path) = self.configuration_file_path.take() {
+                        let _ = self.watcher.unwatch(&configuration_file_path);
+                    }
+                    let _ = self
+                        .watcher
+                        .watch(&path, notify::RecursiveMode::NonRecursive);
+                    self.configuration_file_path = Some(path);
+                }
+                MonitorControl::SetGlobalGitIgnore(path) => {
+                    if let Some(global_gitignore) = self.global_gitignore.take() {
+                        let _ = self.watcher.unwatch(&global_gitignore);
+                    }
+                    let _ = self
+                        .watcher
+                        .watch(&path, notify::RecursiveMode::NonRecursive);
+                    self.global_gitignore = Some(path);
+                }
+                MonitorControl::Shutdown => return ControlFlow::Break(()),
+            }
+
+            ControlFlow::Continue(())
+        }
+
+        fn send_event(
+            &mut self,
+            event_sender: &Sender<super::Event>,
+            control_receiver: &Receiver<MonitorControl>,
+            mut event: super::Event,
+        ) -> ControlFlow<()> {
+            const SEND_TIMEOUT: Duration = Duration::from_millis(50);
+
+            loop {
+                match event_sender.send_timeout(event, SEND_TIMEOUT) {
+                    Ok(()) | Err(crossbeam_channel::SendTimeoutError::Disconnected(_)) => {
+                        return ControlFlow::Continue(());
+                    }
+                    Err(crossbeam_channel::SendTimeoutError::Timeout(not_sent)) => {
+                        event = not_sent;
+                        while let Ok(control) = control_receiver.try_recv() {
+                            self.handle_control(control)?;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     pub fn spawn_monitor_thread(
         event_sender: Sender<super::Event>,
     ) -> anyhow::Result<(JoinHandle<()>, Sender<MonitorControl>)> {
         let (control_sender, control_receiver) = crossbeam_channel::bounded(1);
-        let (fs_event_sender, fs_event_receiver) = crossbeam_channel::bounded(EVENT_QUEUE_SIZE);
+        let (fs_event_sender, fs_event_receiver) = crossbeam_channel::unbounded();
         let watcher_config = notify::Config::default();
         let watcher = notify::RecommendedWatcher::new(fs_event_sender, watcher_config)?;
-        let mut watched_paths: BTreeSet<PathBuf> = BTreeSet::new();
-        let mut configuration_file_path = None;
-        let mut global_gitignore = None;
 
         let thread_handle = std::thread::Builder::new()
             .name("Monitor Thread".to_string())
             .spawn(move || {
-                let mut watcher = watcher;
+                let mut state = MonitorState {
+                    watcher,
+                    watched_paths: BTreeSet::new(),
+                    configuration_file_path: None,
+                    global_gitignore: None,
+                };
+
                 debug!("Monitor starts");
                 loop {
                     select! {
                         recv(fs_event_receiver) -> event => {
                             if let Ok(Ok(event)) = event
                             {
-                                if configuration_file_path.as_ref().is_some_and(|configuration_file_path|{
+                                if (state.configuration_file_path.as_ref().is_some_and(|configuration_file_path|{
                                     event.paths.contains(configuration_file_path)
                                 })
-                                    || global_gitignore
+                                    || state.global_gitignore
                                         .as_ref()
-                                        .is_some_and(|global_gitignore| event.paths.contains(global_gitignore))
+                                        .is_some_and(|global_gitignore| event.paths.contains(global_gitignore)))
+                                    && state.send_event(&event_sender, &control_receiver, crate::commands::monitor::Event::ReloadConfiguration).is_break()
                                 {
-                                    let _ = event_sender.send(crate::commands::monitor::Event::ReloadConfiguration);
+                                    break;
                                 }
 
-                                if accept_event(&event) {
-                                    let _ = event_sender.send(crate::commands::monitor::Event::ScanPaths(event.paths.into_iter().collect()));
+                                if accept_event(&event)
+                                    && state.send_event(&event_sender, &control_receiver, crate::commands::monitor::Event::ScanPaths(event.paths.into_iter().collect())).is_break()
+                                {
+                                    break;
                                 }
                             }
                         }
                         recv(control_receiver) -> control => {
-                            if let Ok(control) = control {
-                                match control {
-                                    MonitorControl::SetWatchedPaths(new_paths, registered) => {
-                                        for path in &watched_paths {
-                                            let _ = watcher.unwatch(path);
-                                        }
-                                        watched_paths.clear();
-                                        for path in new_paths {
-                                            if let Ok(()) = watcher.watch(&path, notify::RecursiveMode::Recursive) {
-                                                watched_paths.insert(path);
-                                            }
-                                        }
-                                        let _ = registered.send(());
-                                    },
-                                    MonitorControl::SetConfigurationFile(path) => {
-                                        if let Some(configuration_file_path) = configuration_file_path.take() {
-                                            let _ = watcher.unwatch(&configuration_file_path);
-                                        }
-                                        let _ = watcher.watch(&path, notify::RecursiveMode::NonRecursive);
-                                        configuration_file_path = Some(path);
-                                    }
-                                    MonitorControl::SetGlobalGitIgnore(path) => {
-                                        if let Some(global_gitignore) = global_gitignore.take() {
-                                            let _ = watcher.unwatch(&global_gitignore);
-                                        }
-                                        let _ = watcher.watch(&path, notify::RecursiveMode::NonRecursive);
-                                        global_gitignore = Some(path);
-                                    }
-                                    MonitorControl::Shutdown => {
-                                        break;
-                                    },
-                                }
+                            if let Ok(control) = control
+                                && state.handle_control(control).is_break()
+                            {
+                                break;
                             }
                         }
                     }
@@ -706,9 +756,17 @@ mod monitor_details {
     #[cfg(test)]
     mod tests {
         use rstest::rstest;
-        use std::{collections::BTreeSet, path::PathBuf, time::Duration};
+        use std::{
+            collections::BTreeSet,
+            path::PathBuf,
+            time::{Duration, Instant},
+        };
+        use temp_dir_builder::TempDirectoryBuilder;
 
-        use crate::commands::monitor::{Event, monitor_details::DebouncerControl};
+        use crate::commands::monitor::{
+            Event,
+            monitor_details::{DebouncerControl, MonitorControl},
+        };
 
         #[rstest]
         #[case(notify::Event::default().set_kind(notify::EventKind::Create(notify::event::CreateKind::File)), true)]
@@ -722,6 +780,99 @@ mod monitor_details {
             let result = super::accept_event(&event);
 
             assert_eq!(accepted, result);
+        }
+
+        fn set_watched_paths(
+            control_sender: &crossbeam_channel::Sender<MonitorControl>,
+            paths: BTreeSet<PathBuf>,
+            timeout: Duration,
+        ) -> Result<(), crossbeam_channel::RecvTimeoutError> {
+            let (registered_sender, registered_receiver) = crossbeam_channel::bounded(1);
+
+            control_sender
+                .send(MonitorControl::SetWatchedPaths(paths, registered_sender))
+                .unwrap();
+
+            registered_receiver.recv_timeout(timeout)
+        }
+
+        #[test]
+        fn test_spawn_monitor_thread_handles_a_control_while_the_event_channel_is_full() {
+            let temp_dir = TempDirectoryBuilder::default().build().unwrap();
+            let temp_dir_path = temp_dir.path().canonicalize().unwrap();
+            let (event_sender, event_receiver) = crossbeam_channel::bounded(1);
+            let (thread_handle, control_sender) =
+                super::spawn_monitor_thread(event_sender).unwrap();
+
+            set_watched_paths(
+                &control_sender,
+                BTreeSet::from([temp_dir_path.clone()]),
+                Duration::from_secs(10),
+            )
+            .unwrap();
+
+            for index in 0..8 {
+                std::fs::write(temp_dir_path.join(format!("filler{index}")), "").unwrap();
+            }
+
+            let deadline = Instant::now() + Duration::from_secs(10);
+            while !event_receiver.is_full() && Instant::now() < deadline {
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            assert!(
+                event_receiver.is_full(),
+                "the watcher never filled the event channel, so the monitor thread never blocked"
+            );
+
+            for index in 0..8 {
+                std::fs::write(temp_dir_path.join(format!("blocked{index}")), "").unwrap();
+            }
+            std::thread::sleep(Duration::from_millis(500));
+
+            let registered =
+                set_watched_paths(&control_sender, BTreeSet::new(), Duration::from_secs(5));
+
+            drop(event_receiver);
+            let _ = control_sender.send(MonitorControl::Shutdown);
+            thread_handle.join().unwrap();
+
+            assert!(
+                registered.is_ok(),
+                "the monitor thread never acknowledged the control because it stayed blocked \
+                 sending an event, so a caller waiting for that acknowledgement deadlocks"
+            );
+        }
+
+        #[test]
+        fn test_spawn_monitor_thread_handles_a_control_while_the_watcher_queue_is_full() {
+            let temp_dir = TempDirectoryBuilder::default().build().unwrap();
+            let temp_dir_path = temp_dir.path().canonicalize().unwrap();
+            let (event_sender, event_receiver) = crossbeam_channel::bounded(1);
+            let (thread_handle, control_sender) =
+                super::spawn_monitor_thread(event_sender).unwrap();
+
+            set_watched_paths(
+                &control_sender,
+                BTreeSet::from([temp_dir_path.clone()]),
+                Duration::from_secs(10),
+            )
+            .unwrap();
+
+            for index in 0..(super::EVENT_QUEUE_SIZE * 4) {
+                std::fs::write(temp_dir_path.join(format!("filler{index}")), "").unwrap();
+            }
+            std::thread::sleep(Duration::from_secs(2));
+
+            assert!(
+                set_watched_paths(&control_sender, BTreeSet::new(), Duration::from_secs(10))
+                    .is_ok(),
+                "the monitor thread never acknowledged the control: unwatch joins the watcher \
+                 thread, which is blocked sending into the queue only the monitor thread drains"
+            );
+
+            drop(event_receiver);
+            let _ = control_sender.send(MonitorControl::Shutdown);
+            thread_handle.join().unwrap();
         }
 
         #[test]

--- a/src/commands/monitor.rs
+++ b/src/commands/monitor.rs
@@ -380,11 +380,16 @@ impl Monitor {
 
 impl Drop for Monitor {
     fn drop(&mut self) {
+        const DRAIN_POLL_INTERVAL: Duration = Duration::from_millis(10);
+
         let _ = self.control_sender.send(MonitorControl::Shutdown);
         let _ = self
             .timemachine_control_sender
             .send(TimeMachineControl::Shutdown);
         while let Some(handle) = self.thread_handles.pop() {
+            while !handle.is_finished() {
+                let _ = self.event_receiver_final.recv_timeout(DRAIN_POLL_INTERVAL);
+            }
             if let Err(error) = super::join_thread(handle) {
                 error!("Failed to join thread: {error}");
             }
@@ -1003,7 +1008,7 @@ mod tests {
     use std::{
         collections::BTreeSet,
         path::{Path, PathBuf},
-        time::Duration,
+        time::{Duration, Instant},
     };
 
     use rstest::rstest;
@@ -1074,6 +1079,42 @@ mod tests {
                  watch was not registered yet when it returned: {other:?}"
             ),
         }
+    }
+
+    #[test]
+    #[serial]
+    fn test_dropping_the_monitor_returns_when_the_event_queue_is_full() {
+        let temp_dir = TempDirectoryBuilder::default().build().unwrap();
+        let temp_dir_path = temp_dir.path().canonicalize().unwrap();
+        let mut monitor = super::Monitor::new().unwrap();
+
+        monitor.set_debounce_duration(Duration::from_millis(1));
+        monitor.set_watched_paths(&BTreeSet::from([temp_dir_path.clone()]));
+
+        let deadline = Instant::now() + Duration::from_secs(30);
+        let mut index = 0;
+        while !monitor.event_receiver_final.is_full() && Instant::now() < deadline {
+            std::fs::write(temp_dir_path.join(format!("file{index}")), "").unwrap();
+            index += 1;
+        }
+        assert!(
+            monitor.event_receiver_final.is_full(),
+            "the watcher never filled the event queue, so the debouncer never blocked"
+        );
+
+        crate::commands::tests::send_sigint();
+
+        let (dropped_sender, dropped_receiver) = crossbeam_channel::bounded(1);
+        std::thread::spawn(move || {
+            drop(monitor);
+            let _ = dropped_sender.send(());
+        });
+
+        assert!(
+            dropped_receiver.recv_timeout(Duration::from_secs(30)).is_ok(),
+            "dropping the monitor never returned: it joins the debouncer while it is blocked \
+             sending into the full event queue, and it stopped draining that queue"
+        );
     }
 
     fn test_iterations(default: usize) -> usize {

--- a/src/commands/monitor.rs
+++ b/src/commands/monitor.rs
@@ -297,6 +297,7 @@ struct Monitor {
     control_sender: Sender<MonitorControl>,
     debouncer_control_sender: Sender<DebouncerControl>,
     timemachine_control_sender: Sender<TimeMachineControl>,
+    signals_handle: signal_hook::iterator::Handle,
     event_receiver_final: Receiver<Event>,
     thread_handles: Vec<JoinHandle<()>>,
     pending_events: BTreeSet<Event>,
@@ -308,7 +309,7 @@ impl Monitor {
             crossbeam_channel::bounded(EVENT_QUEUE_SIZE);
         let (debouncer_thread_handle, debouncer_control_sender, event_receiver_final) =
             monitor_details::spawn_debouncer_thread(event_receiver_debouncer)?;
-        let signals_thread_handle =
+        let (signals_thread_handle, signals_handle) =
             monitor_details::spawn_signals_thread(event_sender_to_debouncer.clone())?;
         let (monitor_thread_handle, monitor_control_sender) =
             monitor_details::spawn_monitor_thread(event_sender_to_debouncer.clone())?;
@@ -319,6 +320,7 @@ impl Monitor {
             control_sender: monitor_control_sender,
             debouncer_control_sender,
             timemachine_control_sender,
+            signals_handle,
             event_receiver_final,
             thread_handles: vec![
                 signals_thread_handle,
@@ -382,6 +384,7 @@ impl Drop for Monitor {
     fn drop(&mut self) {
         const DRAIN_POLL_INTERVAL: Duration = Duration::from_millis(10);
 
+        self.signals_handle.close();
         let _ = self.control_sender.send(MonitorControl::Shutdown);
         let _ = self
             .timemachine_control_sender
@@ -429,12 +432,13 @@ mod monitor_details {
 
     pub fn spawn_signals_thread(
         event_sender: Sender<super::Event>,
-    ) -> anyhow::Result<JoinHandle<()>> {
+    ) -> anyhow::Result<(JoinHandle<()>, signal_hook::iterator::Handle)> {
         let mut signals = signal_hook::iterator::Signals::new([
             signal_hook::consts::SIGTERM,
             signal_hook::consts::SIGINT,
         ])
         .context("Failed to setup signals hooks")?;
+        let signals_handle = signals.handle();
 
         let thread_handle = std::thread::Builder::new()
             .name("Signals Thread".to_string())
@@ -446,7 +450,7 @@ mod monitor_details {
                 debug!("Signals thread shutdowns");
             })?;
 
-        Ok(thread_handle)
+        Ok((thread_handle, signals_handle))
     }
 
     pub enum MonitorControl {
@@ -1115,6 +1119,50 @@ mod tests {
             "dropping the monitor never returned: it joins the debouncer while it is blocked \
              sending into the full event queue, and it stopped draining that queue"
         );
+    }
+
+    #[test]
+    #[serial]
+    fn test_the_event_loop_returns_the_error_it_failed_on() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp_dir = TempDirectoryBuilder::default().build().unwrap();
+        let temp_dir_path = temp_dir.path().canonicalize().unwrap();
+        let repository_path = temp_dir_path.join("repository");
+
+        crate::commands::tests::init_git_repository(&repository_path);
+        std::fs::write(repository_path.join(".gitignore"), "ignored\n").unwrap();
+        std::fs::write(repository_path.join("ignored"), "").unwrap();
+
+        let config_file_path = temp_dir_path.join("config.json");
+        let config = crate::commands::tests::create_config(&repository_path);
+        save_json_file(&config_file_path, &config).unwrap();
+
+        let cache_directory_path = temp_dir_path.join("cache");
+        std::fs::create_dir(&cache_directory_path).unwrap();
+        let cache_file_path = cache_directory_path.join("cache.db");
+        let mut cache = Cache::open_or_create(&cache_file_path).unwrap();
+
+        std::fs::set_permissions(&cache_file_path, PermissionsExt::from_mode(0o444)).unwrap();
+        std::fs::set_permissions(&cache_directory_path, PermissionsExt::from_mode(0o555)).unwrap();
+
+        let (done_sender, done_receiver) = crossbeam_channel::bounded(1);
+        std::thread::spawn(move || {
+            let result = super::execute(&config_file_path, None, &mut cache, false, false);
+            let _ = done_sender.send(format!("{result:?}"));
+        });
+
+        let finished = done_receiver.recv_timeout(Duration::from_secs(15));
+
+        crate::commands::tests::send_sigint();
+        std::fs::set_permissions(&cache_directory_path, PermissionsExt::from_mode(0o755)).unwrap();
+        std::fs::set_permissions(&cache_file_path, PermissionsExt::from_mode(0o644)).unwrap();
+
+        let finished = finished.expect(
+            "monitoring never returned after the scan failed: dropping the monitor joins the \
+             signals thread, which stays blocked until a signal arrives",
+        );
+        assert!(finished.contains("readonly"), "unexpected outcome: {finished}");
     }
 
     fn test_iterations(default: usize) -> usize {

--- a/src/commands/monitor.rs
+++ b/src/commands/monitor.rs
@@ -1123,6 +1123,124 @@ mod tests {
 
     #[test]
     #[serial]
+    fn test_rescan_removes_a_directory_exclusion_when_a_non_ignored_file_appears_in_it() {
+        let temp_dir = TempDirectoryBuilder::default().build().unwrap();
+        let temp_dir_path = temp_dir.path().canonicalize().unwrap();
+        let main_path = temp_dir_path.join("main");
+
+        crate::commands::tests::init_git_repository(&main_path);
+        std::fs::write(main_path.join(".gitignore"), "*.log\n").unwrap();
+        commit_all(&main_path, "init main repository");
+
+        let big_dir_path = main_path.join("big_dir");
+        std::fs::create_dir_all(&big_dir_path).unwrap();
+        std::fs::write(big_dir_path.join("a.log"), "").unwrap();
+        std::fs::write(big_dir_path.join("b.log"), "").unwrap();
+
+        let mut cache = Cache::open_in_memory().unwrap();
+        let config = crate::commands::tests::create_config(&main_path);
+
+        super::super::run::execute(&config, &mut cache, false, false).unwrap();
+
+        let cached_paths: BTreeSet<_> = cache.paths().unwrap().into_iter().collect();
+        assert!(
+            cached_paths.contains(&big_dir_path),
+            "the initial scan should have excluded the wholly ignored directory"
+        );
+
+        let kept_path = big_dir_path.join("keep.txt");
+        std::fs::write(&kept_path, "").unwrap();
+
+        let cached_paths = rescan(
+            &mut cache,
+            config,
+            &temp_dir_path,
+            BTreeSet::from([kept_path]),
+        );
+
+        assert_eq!(
+            cached_paths,
+            BTreeSet::from([big_dir_path.join("a.log"), big_dir_path.join("b.log")]),
+            "the directory is no longer wholly ignored so git stopped collapsing it: its \
+             exclusion must be removed, otherwise the new file is left out of the backup, \
+             and the exclusions of the ignored files it contains must be kept"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_rescan_main_repository_removes_the_exclusion_it_created_for_a_nested_repository() {
+        let temp_dir = TempDirectoryBuilder::default().build().unwrap();
+        let temp_dir_path = temp_dir.path().canonicalize().unwrap();
+        let main_path = temp_dir_path.join("main");
+
+        crate::commands::tests::init_git_repository(&main_path);
+        std::fs::write(main_path.join(".gitignore"), "ignored_in_main\n").unwrap();
+        commit_all(&main_path, "init main repository");
+
+        let nested_path = main_path.join("nested");
+        crate::commands::tests::init_git_repository(&nested_path);
+        std::fs::write(nested_path.join(".gitignore"), "ignored_in_nested\n").unwrap();
+        commit_all(&nested_path, "init nested repository");
+
+        std::fs::write(nested_path.join("ignored_in_nested"), "").unwrap();
+        std::fs::write(main_path.join("ignored_in_main"), "").unwrap();
+
+        let main_ignored_path = main_path.join("ignored_in_main");
+        let nested_ignored_path = nested_path.join("ignored_in_nested");
+
+        let mut cache = Cache::open_in_memory().unwrap();
+        let config = crate::commands::tests::create_config(&main_path);
+
+        super::super::run::execute(&config, &mut cache, false, false).unwrap();
+
+        let cached_paths: BTreeSet<_> = cache.paths().unwrap().into_iter().collect();
+        assert_eq!(
+            cached_paths,
+            BTreeSet::from([main_ignored_path.clone(), nested_ignored_path.clone()]),
+            "the initial scan should have excluded the ignored file of each repository"
+        );
+
+        std::fs::write(main_path.join(".gitignore"), "ignored_in_main\nnested/\n").unwrap();
+
+        let cached_paths = rescan(
+            &mut cache,
+            config,
+            &temp_dir_path,
+            BTreeSet::from([main_path.join(".gitignore")]),
+        );
+
+        assert_eq!(
+            cached_paths,
+            BTreeSet::from([
+                main_ignored_path.clone(),
+                nested_path.clone(),
+                nested_ignored_path.clone()
+            ]),
+            "the main repository now gitignores the nested repository, so it must exclude it \
+             without dropping the exclusion owned by the nested repository"
+        );
+
+        std::fs::write(main_path.join(".gitignore"), "ignored_in_main\n").unwrap();
+
+        let cached_paths = rescan(
+            &mut cache,
+            crate::commands::tests::create_config(&main_path),
+            &temp_dir_path,
+            BTreeSet::from([main_path.join(".gitignore")]),
+        );
+
+        assert_eq!(
+            cached_paths,
+            BTreeSet::from([main_ignored_path, nested_ignored_path]),
+            "the main repository created the exclusion of the nested repository and no longer \
+             gitignores it, so rescanning the main repository must remove it and keep the \
+             exclusion owned by the nested repository"
+        );
+    }
+
+    #[test]
+    #[serial]
     fn test_rescan_large_ignored_tree_preserves_exclusions() {
         let temp_dir = TempDirectoryBuilder::default().build().unwrap();
         let temp_dir_path = temp_dir.path().canonicalize().unwrap();

--- a/src/commands/monitor.rs
+++ b/src/commands/monitor.rs
@@ -1166,6 +1166,72 @@ mod tests {
     }
 
     #[test]
+    #[serial]
+    #[ignore = "large-scale scenario kept for stress-testing and manual profiling; run explicitly with `cargo test -- --ignored`"]
+    fn test_rescan_large_ignored_tree_preserves_exclusions_at_scale() {
+        let temp_dir = TempDirectoryBuilder::default().build().unwrap();
+        let temp_dir_path = temp_dir.path().canonicalize().unwrap();
+        let main_path = temp_dir_path.join("main");
+
+        crate::commands::tests::init_git_repository(&main_path);
+        std::fs::write(main_path.join(".gitignore"), "*.ignored\n").unwrap();
+        commit_all(&main_path, "init main repository");
+
+        let deep_path = main_path.join("a").join("b").join("c");
+        std::fs::create_dir_all(&deep_path).unwrap();
+        std::fs::write(deep_path.join(".keep"), "").unwrap();
+        commit_all(&main_path, "add deep sentinel");
+
+        // Defaults to a genuinely large scenario for manual stress-testing/profiling;
+        // CI overrides this to a tiny value via TMIGNORE_RS_TEST_ITERATIONS, since it
+        // only needs to confirm the scenario still passes, not exercise it at scale.
+        let iterations: usize = match std::env::var("TMIGNORE_RS_TEST_ITERATIONS") {
+            Ok(value) => value.parse().unwrap_or_else(|error| {
+                panic!("TMIGNORE_RS_TEST_ITERATIONS='{value}' is not a valid usize: {error}")
+            }),
+            Err(_) => 100000,
+        };
+
+        let mut ignored_paths = BTreeSet::new();
+        for i in 0..iterations {
+            let file_path = deep_path.join(format!("file_{i}.ignored"));
+            std::fs::write(&file_path, "").unwrap();
+            ignored_paths.insert(file_path);
+        }
+
+        let mut cache = Cache::open_in_memory().unwrap();
+        let config = crate::commands::tests::create_config(&main_path);
+
+        super::super::run::execute(&config, &mut cache, false, false).unwrap();
+
+        let cached_paths: BTreeSet<_> = cache.paths().unwrap().into_iter().collect();
+        for path in &ignored_paths {
+            assert!(
+                cached_paths.contains(path),
+                "the initial scan should have excluded every ignored file"
+            );
+        }
+        assert_eq!(cached_paths.len(), ignored_paths.len());
+
+        std::fs::write(main_path.join(".gitignore"), "*.ignored\n\n").unwrap();
+
+        let cached_paths = rescan(
+            &mut cache,
+            config,
+            &temp_dir_path,
+            BTreeSet::from([main_path.join(".gitignore")]),
+        );
+
+        for path in &ignored_paths {
+            assert!(
+                cached_paths.contains(path),
+                "rescanning must not drop cached exclusions under a large ignored directory"
+            );
+        }
+        assert_eq!(cached_paths.len(), ignored_paths.len());
+    }
+
+    #[test]
     fn test_find_repositories_to_scan() {
         let temp_dir = TempDirectoryBuilder::default()
             .add_directory("repository/.git")

--- a/src/commands/monitor.rs
+++ b/src/commands/monitor.rs
@@ -74,7 +74,7 @@ fn handle_event(
                 &context.config.search_directories,
                 context.cache,
             )?;
-            for repository_to_scan in &repositories_to_scan {
+            for (repository_to_scan, changed_paths) in &repositories_to_scan {
                 debug!("Scanning repository '{}'", repository_to_scan.display());
                 let mut exclusions = Vec::new();
                 super::find_paths_to_exclude_from_backup(
@@ -96,6 +96,18 @@ fn handle_event(
                         repository_to_scan.display()
                     );
                     continue;
+                }
+
+                if context.details {
+                    info!(
+                        "Detected {} changed {} in '{}'",
+                        changed_paths.len(),
+                        crate::text::plural("path", changed_paths.len()),
+                        repository_to_scan.display()
+                    );
+                    for changed_path in changed_paths {
+                        info!("~ {}", changed_path.display());
+                    }
                 }
 
                 let paths_failed_to_add = super::apply_diff_and_print::<TimeMachine>(
@@ -142,11 +154,11 @@ fn handle_event(
 ///   its directory, so the exclusion of that directory must be removed.
 ///
 /// The repository is scanned as soon as one of its paths is not skipped.
-fn find_repositories_to_scan(
-    paths: &BTreeSet<PathBuf>,
+fn find_repositories_to_scan<'a>(
+    paths: &'a BTreeSet<PathBuf>,
     search_directories: &BTreeSet<PathBuf>,
     cache: &Cache,
-) -> Result<BTreeSet<PathBuf>, anyhow::Error> {
+) -> Result<BTreeMap<PathBuf, Vec<&'a Path>>, anyhow::Error> {
     let mut paths_by_repository: BTreeMap<PathBuf, Vec<&Path>> = BTreeMap::new();
 
     for path in paths {
@@ -162,7 +174,7 @@ fn find_repositories_to_scan(
         }
     }
 
-    let mut repositories = BTreeSet::new();
+    let mut repositories = BTreeMap::new();
 
     for (repository_path, repository_paths) in paths_by_repository {
         let mut scan = false;
@@ -177,7 +189,7 @@ fn find_repositories_to_scan(
         // Checking whether the paths are ignored costs a git process, so it runs once for the
         // whole batch and only when the cheap checks did not already settle the repository.
         if scan || crate::git::contains_not_ignored_path(&repository_path, &repository_paths) {
-            repositories.insert(repository_path);
+            repositories.insert(repository_path, repository_paths);
         }
     }
 
@@ -1115,7 +1127,9 @@ mod tests {
         });
 
         assert!(
-            dropped_receiver.recv_timeout(Duration::from_secs(30)).is_ok(),
+            dropped_receiver
+                .recv_timeout(Duration::from_secs(30))
+                .is_ok(),
             "dropping the monitor never returned: it joins the debouncer while it is blocked \
              sending into the full event queue, and it stopped draining that queue"
         );
@@ -1162,7 +1176,10 @@ mod tests {
             "monitoring never returned after the scan failed: dropping the monitor joins the \
              signals thread, which stays blocked until a signal arrives",
         );
-        assert!(finished.contains("readonly"), "unexpected outcome: {finished}");
+        assert!(
+            finished.contains("readonly"),
+            "unexpected outcome: {finished}"
+        );
     }
 
     fn test_iterations(default: usize) -> usize {
@@ -1927,6 +1944,8 @@ mod tests {
         let scan = |paths: [PathBuf; 1]| {
             super::find_repositories_to_scan(&BTreeSet::from(paths), &search_directories, &cache)
                 .unwrap()
+                .into_keys()
+                .collect::<BTreeSet<_>>()
         };
         let scanned = BTreeSet::from([repository_path.clone()]);
 
@@ -1975,15 +1994,23 @@ mod tests {
             "a repository outside the search directories must not be scanned"
         );
 
-        let repositories = super::find_repositories_to_scan(
-            &BTreeSet::from([logs_path.join("a.log"), kept_path]),
-            &search_directories,
-            &cache,
-        )
-        .unwrap();
+        let changed_paths = [logs_path.join("a.log"), kept_path];
+        let paths = BTreeSet::from(changed_paths.clone());
+        let repositories =
+            super::find_repositories_to_scan(&paths, &search_directories, &cache).unwrap();
         assert_eq!(
-            scanned, repositories,
+            scanned,
+            repositories.keys().cloned().collect::<BTreeSet<_>>(),
             "a single path that is not ignored is enough to scan the repository"
+        );
+        assert_eq!(
+            changed_paths
+                .iter()
+                .map(PathBuf::as_path)
+                .collect::<Vec<_>>(),
+            repositories[&repository_path],
+            "the repository keeps every changed path that belongs to it, so the caller can report \
+             what triggered the scan"
         );
     }
 

--- a/src/commands/monitor.rs
+++ b/src/commands/monitor.rs
@@ -83,15 +83,24 @@ fn handle_event(
                     &mut exclusions,
                 )?;
 
-                let owned_paths: BTreeSet<PathBuf> = context
-                    .cache
-                    .paths_with_prefix(repository_to_scan)?
-                    .into_iter()
-                    .filter(|path| {
-                        crate::git::find_parent_repository(path).as_deref()
-                            == Some(repository_to_scan.as_path())
-                    })
-                    .collect();
+                let cached_paths = context.cache.paths_with_prefix(repository_to_scan)?;
+                let nested_repositories = crate::git::find_nested_repositories(
+                    repository_to_scan,
+                    &context.config.ignored_directories,
+                    context.config.threads,
+                )?;
+                let owned_paths: BTreeSet<PathBuf> = if nested_repositories.is_empty() {
+                    cached_paths.into_iter().collect()
+                } else {
+                    cached_paths
+                        .into_iter()
+                        .filter(|path| {
+                            !nested_repositories
+                                .iter()
+                                .any(|nested| path.starts_with(nested))
+                        })
+                        .collect()
+                };
 
                 let diff = Diff {
                     added: exclusions.difference(&owned_paths).cloned().collect(),
@@ -1051,7 +1060,8 @@ mod tests {
 
     #[test]
     #[serial]
-    fn test_rescan_main_repository_does_not_remove_submodule_exclusions_when_submodule_directory_is_gitignored() {
+    fn test_rescan_main_repository_does_not_remove_submodule_exclusions_when_submodule_directory_is_gitignored()
+     {
         let temp_dir = TempDirectoryBuilder::default().build().unwrap();
         let temp_dir_path = temp_dir.path().canonicalize().unwrap();
         let sub_source_path = temp_dir_path.join("sub_source");
@@ -1189,7 +1199,7 @@ mod tests {
             Ok(value) => value.parse().unwrap_or_else(|error| {
                 panic!("TMIGNORE_RS_TEST_ITERATIONS='{value}' is not a valid usize: {error}")
             }),
-            Err(_) => 100000,
+            Err(_) => 100_000,
         };
 
         let mut ignored_paths = BTreeSet::new();

--- a/src/commands/monitor.rs
+++ b/src/commands/monitor.rs
@@ -76,30 +76,23 @@ fn handle_event(
             )?;
             for repository_to_scan in &repositories_to_scan {
                 debug!("Scanning repository '{}'", repository_to_scan.display());
-                let mut exclusions = BTreeSet::new();
+                let mut exclusions = Vec::new();
                 super::find_paths_to_exclude_from_backup(
                     repository_to_scan,
                     context.whitelist,
                     &mut exclusions,
                 )?;
+                exclusions.sort_unstable();
+                exclusions.dedup();
 
-                let cached_paths: BTreeSet<PathBuf> = context
-                    .cache
-                    .paths_with_prefix(repository_to_scan)?
-                    .into_iter()
-                    .collect();
+                let mut cached_paths = context.cache.paths_with_prefix(repository_to_scan)?;
+                cached_paths.sort_unstable();
 
-                let diff = Diff {
-                    added: exclusions.difference(&cached_paths).cloned().collect(),
-                    removed: cached_paths
-                        .difference(&exclusions)
-                        .filter(|path| {
-                            crate::git::find_parent_repository(path).as_deref()
-                                == Some(repository_to_scan.as_path())
-                        })
-                        .cloned()
-                        .collect(),
-                };
+                let mut diff = Diff::from_sorted(&exclusions, &cached_paths);
+                diff.removed.retain(|path| {
+                    crate::git::find_parent_repository(path).as_deref()
+                        == Some(repository_to_scan.as_path())
+                });
 
                 if diff.added.is_empty() && diff.removed.is_empty() {
                     debug!(
@@ -122,7 +115,7 @@ fn handle_event(
                     let paths_to_add = diff
                         .added
                         .iter()
-                        .filter(|path| !paths_failed_to_add.contains(path))
+                        .filter(|path| !paths_failed_to_add.contains(*path))
                         .cloned();
                     context.cache.add_paths(paths_to_add)?;
                 }

--- a/src/commands/monitor.rs
+++ b/src/commands/monitor.rs
@@ -1050,6 +1050,122 @@ mod tests {
     }
 
     #[test]
+    #[serial]
+    fn test_rescan_main_repository_does_not_remove_submodule_exclusions_when_submodule_directory_is_gitignored() {
+        let temp_dir = TempDirectoryBuilder::default().build().unwrap();
+        let temp_dir_path = temp_dir.path().canonicalize().unwrap();
+        let sub_source_path = temp_dir_path.join("sub_source");
+        let main_path = temp_dir_path.join("main");
+
+        crate::commands::tests::init_git_repository(&sub_source_path);
+        std::fs::write(sub_source_path.join(".gitignore"), "ignored_in_sub\n").unwrap();
+        commit_all(&sub_source_path, "init submodule source");
+
+        crate::commands::tests::init_git_repository(&main_path);
+        std::fs::write(main_path.join(".gitignore"), "ignored_in_main\n").unwrap();
+        commit_all(&main_path, "init main repository");
+        run_git(&[
+            "-c",
+            "protocol.file.allow=always",
+            "-C",
+            main_path.to_str().unwrap(),
+            "submodule",
+            "add",
+            "-q",
+            sub_source_path.to_str().unwrap(),
+            "submodule",
+        ]);
+        commit_all(&main_path, "add submodule");
+
+        std::fs::write(main_path.join("submodule").join("ignored_in_sub"), "").unwrap();
+        std::fs::write(main_path.join("ignored_in_main"), "").unwrap();
+
+        let mut cache = Cache::open_in_memory().unwrap();
+        let config = crate::commands::tests::create_config(&main_path);
+
+        super::super::run::execute(&config, &mut cache, false, false).unwrap();
+
+        let submodule_ignored_path = main_path.join("submodule").join("ignored_in_sub");
+        let main_ignored_path = main_path.join("ignored_in_main");
+
+        let cached_paths: BTreeSet<_> = cache.paths().unwrap().into_iter().collect();
+        assert!(
+            cached_paths.contains(&submodule_ignored_path),
+            "the initial scan should have excluded the submodule's ignored file"
+        );
+        assert!(cached_paths.contains(&main_ignored_path));
+
+        std::fs::write(
+            main_path.join(".gitignore"),
+            "ignored_in_main\nsubmodule/\n",
+        )
+        .unwrap();
+
+        let cached_paths = rescan(
+            &mut cache,
+            config,
+            &temp_dir_path,
+            BTreeSet::from([main_path.join(".gitignore")]),
+        );
+
+        assert!(
+            cached_paths.contains(&submodule_ignored_path),
+            "rescanning the main repository must not remove the submodule's exclusions \
+             even though the submodule's directory is itself gitignored"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_rescan_large_ignored_tree_preserves_exclusions() {
+        let temp_dir = TempDirectoryBuilder::default().build().unwrap();
+        let temp_dir_path = temp_dir.path().canonicalize().unwrap();
+        let main_path = temp_dir_path.join("main");
+
+        crate::commands::tests::init_git_repository(&main_path);
+        std::fs::write(main_path.join(".gitignore"), "*.ignored\n").unwrap();
+        commit_all(&main_path, "init main repository");
+
+        let mut ignored_paths = BTreeSet::new();
+        for i in 0..1000 {
+            let file_path = main_path.join(format!("file_{i}.ignored"));
+            std::fs::write(&file_path, "").unwrap();
+            ignored_paths.insert(file_path);
+        }
+
+        let mut cache = Cache::open_in_memory().unwrap();
+        let config = crate::commands::tests::create_config(&main_path);
+
+        super::super::run::execute(&config, &mut cache, false, false).unwrap();
+
+        let cached_paths: BTreeSet<_> = cache.paths().unwrap().into_iter().collect();
+        for path in &ignored_paths {
+            assert!(
+                cached_paths.contains(path),
+                "the initial scan should have excluded every ignored file"
+            );
+        }
+        assert_eq!(cached_paths.len(), ignored_paths.len());
+
+        std::fs::write(main_path.join(".gitignore"), "*.ignored\n\n").unwrap();
+
+        let cached_paths = rescan(
+            &mut cache,
+            config,
+            &temp_dir_path,
+            BTreeSet::from([main_path.join(".gitignore")]),
+        );
+
+        for path in &ignored_paths {
+            assert!(
+                cached_paths.contains(path),
+                "rescanning must not drop cached exclusions when many paths are cached"
+            );
+        }
+        assert_eq!(cached_paths.len(), ignored_paths.len());
+    }
+
+    #[test]
     fn test_find_repositories_to_scan() {
         let temp_dir = TempDirectoryBuilder::default()
             .add_directory("repository/.git")

--- a/src/commands/monitor.rs
+++ b/src/commands/monitor.rs
@@ -83,28 +83,22 @@ fn handle_event(
                     &mut exclusions,
                 )?;
 
-                let cached_paths = context.cache.paths_with_prefix(repository_to_scan)?;
-                let nested_repositories = crate::git::find_nested_repositories(
-                    repository_to_scan,
-                    &context.config.ignored_directories,
-                    context.config.threads,
-                )?;
-                let owned_paths: BTreeSet<PathBuf> = if nested_repositories.is_empty() {
-                    cached_paths.into_iter().collect()
-                } else {
-                    cached_paths
-                        .into_iter()
-                        .filter(|path| {
-                            !nested_repositories
-                                .iter()
-                                .any(|nested| path.starts_with(nested))
-                        })
-                        .collect()
-                };
+                let cached_paths: BTreeSet<PathBuf> = context
+                    .cache
+                    .paths_with_prefix(repository_to_scan)?
+                    .into_iter()
+                    .collect();
 
                 let diff = Diff {
-                    added: exclusions.difference(&owned_paths).cloned().collect(),
-                    removed: owned_paths.difference(&exclusions).cloned().collect(),
+                    added: exclusions.difference(&cached_paths).cloned().collect(),
+                    removed: cached_paths
+                        .difference(&exclusions)
+                        .filter(|path| {
+                            crate::git::find_parent_repository(path).as_deref()
+                                == Some(repository_to_scan.as_path())
+                        })
+                        .cloned()
+                        .collect(),
                 };
 
                 if diff.added.is_empty() && diff.removed.is_empty() {

--- a/src/commands/reset.rs
+++ b/src/commands/reset.rs
@@ -1,9 +1,7 @@
 use crate::{cache::Cache, commands::TimeMachine};
 
-use std::collections::BTreeSet;
-
 pub fn execute(cache: &mut Cache, dry_run: bool, details: bool) -> anyhow::Result<()> {
-    let diff = cache.find_diff(&BTreeSet::new())?;
+    let diff = cache.find_diff(&[])?;
 
     super::apply_diff_and_print::<TimeMachine>(&diff, dry_run, details);
 

--- a/src/commands/reset.rs
+++ b/src/commands/reset.rs
@@ -14,13 +14,11 @@ pub fn execute(cache: &mut Cache, dry_run: bool, details: bool) -> anyhow::Resul
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
-
     use crate::cache::Cache;
 
     #[test]
     fn test_reset() {
-        let temp_dir = crate::commands::tests::create_repository(None::<PathBuf>);
+        let temp_dir = crate::commands::tests::create_repository(None);
         let mut cache = Cache::open_in_memory().unwrap();
         let config = crate::commands::tests::create_config(temp_dir.path());
         let dry_run = false;

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -26,9 +26,13 @@ pub fn execute(
         config.threads,
     ) {
         while let Ok(repository_path) = rx.recv() {
-            repositories.insert(repository_path.clone());
-
-            super::find_paths_to_exclude_from_backup(repository_path, &whitelist, &mut exclusions)?;
+            if repositories.insert(repository_path.clone()) {
+                super::find_paths_to_exclude_from_backup(
+                    repository_path,
+                    &whitelist,
+                    &mut exclusions,
+                )?;
+            }
         }
 
         super::join_thread(thread_handle)?;
@@ -125,6 +129,57 @@ pub(crate) mod tests {
             !crate::timemachine::tests::is_excluded_from_time_machine(&target_path),
             "the Time Machine exclusion was applied to the target of a gitignored symlink, \
              outside the repository"
+        );
+    }
+
+    #[test]
+    fn test_overlapping_search_directories_scan_every_repository_once() {
+        let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("test_run_overlapping_search");
+        if root.exists() && root.is_dir() {
+            std::fs::remove_dir_all(&root).unwrap();
+        }
+        let temp_dir = TempDirectoryBuilder::default()
+            .root_folder(&root)
+            .add_text_file("nested/repository/.gitignore", "a\n")
+            .add_empty_file("nested/repository/a")
+            .add_empty_file("nested/repository/kept")
+            .add_text_file("other_repository/.gitignore", "b\n")
+            .add_empty_file("other_repository/b")
+            .add_empty_file("other_repository/kept")
+            .build()
+            .unwrap();
+        let nested_path = temp_dir.path().join("nested");
+        let repository_path = nested_path.join("repository");
+        let other_repository_path = temp_dir.path().join("other_repository");
+        crate::commands::tests::init_git_repository(&repository_path);
+        crate::commands::tests::init_git_repository(&other_repository_path);
+
+        let mut config = crate::commands::tests::create_config(temp_dir.path());
+        config.search_directories.insert(nested_path);
+
+        let mut cache = Cache::open_in_memory().unwrap();
+        crate::commands::tests::FIND_PATHS_TO_EXCLUDE_CALLS.with(|calls| calls.set(0));
+
+        super::execute(&config, &mut cache, false, false).unwrap();
+
+        assert_eq!(
+            2,
+            crate::commands::tests::FIND_PATHS_TO_EXCLUDE_CALLS.with(std::cell::Cell::get),
+            "'nested/repository' is reported by both overlapping search directories, so it was \
+             scanned twice instead of once"
+        );
+
+        let mut expected = vec![
+            repository_path.canonicalize().unwrap().join("a"),
+            other_repository_path.canonicalize().unwrap().join("b"),
+        ];
+        expected.sort_unstable();
+        let mut paths = cache.paths().unwrap();
+        paths.sort_unstable();
+
+        assert_eq!(
+            expected, paths,
+            "scanning each repository once dropped the exclusions of a repository"
         );
     }
 

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -68,8 +68,6 @@ pub fn execute(
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use std::path::PathBuf;
-
     use temp_dir_builder::TempDirectoryBuilder;
 
     use crate::cache::Cache;
@@ -102,10 +100,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_gitignored_symlink_does_not_exclude_target() {
-        let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("test_run_gitignored_symlink");
-        if root.exists() && root.is_dir() {
-            std::fs::remove_dir_all(&root).unwrap();
-        }
+        let root = crate::commands::tests::prepare_test_directory("test_run_gitignored_symlink");
         let temp_dir = TempDirectoryBuilder::default()
             .root_folder(&root)
             .add_text_file("outside/precious.txt", "precious data")
@@ -134,10 +129,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_overlapping_search_directories_scan_every_repository_once() {
-        let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("test_run_overlapping_search");
-        if root.exists() && root.is_dir() {
-            std::fs::remove_dir_all(&root).unwrap();
-        }
+        let root = crate::commands::tests::prepare_test_directory("test_run_overlapping_search");
         let temp_dir = TempDirectoryBuilder::default()
             .root_folder(&root)
             .add_text_file("nested/repository/.gitignore", "a\n")

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeSet, path::PathBuf};
+use std::collections::BTreeSet;
 
 use log::info;
 
@@ -6,6 +6,7 @@ use crate::{
     cache::Cache,
     commands::TimeMachine,
     config::Config,
+    diff::Exclusion,
     git::{self},
 };
 
@@ -17,7 +18,7 @@ pub fn execute(
 ) -> anyhow::Result<()> {
     let whitelist = super::create_whitelist(&config.whitelist_patterns)?;
     let mut repositories = BTreeSet::new();
-    let mut exclusions: Vec<PathBuf> = Vec::new();
+    let mut exclusions: Vec<Exclusion> = Vec::new();
 
     info!("Searching for Git repositories...");
     if let Some((rx, thread_handle)) = git::find_repositories(
@@ -56,7 +57,7 @@ pub fn execute(
         let paths_failed_to_add =
             super::apply_diff_and_print::<TimeMachine>(&diff, dry_run, details);
 
-        exclusions.retain(|path| !paths_failed_to_add.contains(path));
+        exclusions.retain(|exclusion| !paths_failed_to_add.contains(exclusion.path()));
 
         if !dry_run {
             cache.reset(exclusions)?;

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -131,6 +131,44 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn test_case_only_rename_keeps_the_directory_excluded() {
+        let root = crate::commands::tests::prepare_test_directory("test_run_case_only_rename");
+        let temp_dir = TempDirectoryBuilder::default()
+            .root_folder(&root)
+            .add_text_file("repository/.gitignore", "Foo\n")
+            .add_empty_file("repository/Foo/a")
+            .build()
+            .unwrap();
+        let repository_path = temp_dir.path().join("repository");
+        crate::commands::tests::init_git_repository(&repository_path);
+
+        let mut cache = Cache::open_in_memory().unwrap();
+        let config = crate::commands::tests::create_config(&repository_path);
+
+        super::execute(&config, &mut cache, false, false).unwrap();
+
+        let upper_case_path = repository_path.join("Foo");
+        assert!(
+            crate::timemachine::tests::is_excluded_from_time_machine(&upper_case_path),
+            "the initial scan should have excluded the ignored directory"
+        );
+
+        let lower_case_path = repository_path.join("foo");
+        std::fs::rename(&upper_case_path, repository_path.join("renamed")).unwrap();
+        std::fs::rename(repository_path.join("renamed"), &lower_case_path).unwrap();
+        std::fs::write(repository_path.join(".gitignore"), "foo\n").unwrap();
+
+        super::execute(&config, &mut cache, false, false).unwrap();
+
+        assert!(
+            crate::timemachine::tests::is_excluded_from_time_machine(&lower_case_path),
+            "the directory was renamed by case only so it is the same directory, and the \
+             filesystem is case insensitive, so removing the old spelling must not undo the \
+             exclusion of the new one"
+        );
+    }
+
+    #[test]
     fn test_overlapping_search_directories_scan_every_repository_once() {
         let root = crate::commands::tests::prepare_test_directory("test_run_overlapping_search");
         let temp_dir = TempDirectoryBuilder::default()

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeSet;
+use std::{collections::BTreeSet, path::PathBuf};
 
 use log::info;
 
@@ -17,7 +17,7 @@ pub fn execute(
 ) -> anyhow::Result<()> {
     let whitelist = super::create_whitelist(&config.whitelist_patterns)?;
     let mut repositories = BTreeSet::new();
-    let mut exclusions = BTreeSet::new();
+    let mut exclusions: Vec<PathBuf> = Vec::new();
 
     info!("Searching for Git repositories...");
     if let Some((rx, thread_handle)) = git::find_repositories(
@@ -32,6 +32,8 @@ pub fn execute(
         }
 
         super::join_thread(thread_handle)?;
+        exclusions.sort_unstable();
+        exclusions.dedup();
 
         info!(
             "Found {} {}",
@@ -50,9 +52,7 @@ pub fn execute(
         let paths_failed_to_add =
             super::apply_diff_and_print::<TimeMachine>(&diff, dry_run, details);
 
-        for path in paths_failed_to_add {
-            exclusions.remove(&path);
-        }
+        exclusions.retain(|path| !paths_failed_to_add.contains(path));
 
         if !dry_run {
             cache.reset(exclusions)?;

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -68,13 +68,16 @@ pub fn execute(
 
 #[cfg(test)]
 pub(crate) mod tests {
+    use std::path::Path;
+
     use temp_dir_builder::TempDirectoryBuilder;
 
     use crate::cache::Cache;
 
     #[test]
     fn test_command() {
-        let temp_dir = crate::commands::tests::create_repository(Some("test_run_command"));
+        let temp_dir =
+            crate::commands::tests::create_repository(Some(Path::new("test_run_command")));
         let mut cache = Cache::open_in_memory().unwrap();
         let config = crate::commands::tests::create_config(temp_dir.path());
         let dry_run = false;
@@ -177,8 +180,9 @@ pub(crate) mod tests {
 
     #[test]
     fn test_dry_run() {
-        let temp_dir =
-            crate::commands::tests::create_repository(Some("run_command_test_command_dry_run"));
+        let temp_dir = crate::commands::tests::create_repository(Some(Path::new(
+            "run_command_test_command_dry_run",
+        )));
         let mut cache = Cache::open_in_memory().unwrap();
         let config = crate::commands::tests::create_config(temp_dir.path());
         let dry_run = true;

--- a/src/commands/stats.rs
+++ b/src/commands/stats.rs
@@ -97,7 +97,9 @@ mod tests {
         let mut cache = Cache::open_in_memory().unwrap();
         let a = temp_dir.path().join("a");
         let dir = temp_dir.path().join("dir");
-        cache.add_paths([a, dir].into_iter()).unwrap();
+        cache
+            .add_paths([a, dir].into_iter().map(crate::diff::Exclusion::orphan))
+            .unwrap();
         let mut buffer = vec![];
         let stat_command = Stats::Size { humanize: false };
         super::execute(&cache, &mut buffer, stat_command).unwrap();
@@ -115,7 +117,11 @@ mod tests {
             .unwrap();
         let mut cache = Cache::open_in_memory().unwrap();
         cache
-            .add_paths([temp_dir.path().join("a")].into_iter())
+            .add_paths(
+                [temp_dir.path().join("a")]
+                    .into_iter()
+                    .map(crate::diff::Exclusion::orphan),
+            )
             .unwrap();
         let mut buffer = vec![];
 
@@ -133,7 +139,11 @@ mod tests {
             .unwrap();
         let mut cache = Cache::open_in_memory().unwrap();
         cache
-            .add_paths([temp_dir.path().join("top")].into_iter())
+            .add_paths(
+                [temp_dir.path().join("top")]
+                    .into_iter()
+                    .map(crate::diff::Exclusion::orphan),
+            )
             .unwrap();
         let mut buffer = vec![];
 

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -5,3 +5,21 @@ pub struct Diff {
     pub added: BTreeSet<PathBuf>,
     pub removed: BTreeSet<PathBuf>,
 }
+
+impl Diff {
+    /// `current` and `previous` must already be sorted: this uses `binary_search` against them.
+    pub fn from_sorted(current: &[PathBuf], previous: &[PathBuf]) -> Self {
+        Self {
+            added: current
+                .iter()
+                .filter(|path| previous.binary_search(path).is_err())
+                .cloned()
+                .collect(),
+            removed: previous
+                .iter()
+                .filter(|path| current.binary_search(path).is_err())
+                .cloned()
+                .collect(),
+        }
+    }
+}

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -1,4 +1,37 @@
-use std::{collections::BTreeSet, path::PathBuf};
+use std::{
+    collections::BTreeSet,
+    path::{Path, PathBuf},
+};
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
+pub struct Exclusion {
+    path: PathBuf,
+    repository: Option<PathBuf>,
+}
+
+impl Exclusion {
+    pub fn new(path: PathBuf, repository: PathBuf) -> Self {
+        Self {
+            path,
+            repository: Some(repository),
+        }
+    }
+
+    pub fn orphan(path: PathBuf) -> Self {
+        Self {
+            path,
+            repository: None,
+        }
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub fn repository(&self) -> Option<&Path> {
+        self.repository.as_deref()
+    }
+}
 
 #[derive(Default)]
 pub struct Diff {
@@ -7,20 +40,32 @@ pub struct Diff {
 }
 
 impl Diff {
-    /// `current` and `previous` must already be sorted: this uses `binary_search` against them.
-    pub fn from_sorted(current: &[PathBuf], previous: &[PathBuf]) -> Self {
-        debug_assert!(current.is_sorted(), "`current` must be sorted");
+    /// `current` and `previous` must already be sorted by path: this uses `binary_search` against
+    /// them.
+    pub fn from_sorted(current: &[Exclusion], previous: &[PathBuf]) -> Self {
+        debug_assert!(
+            current.is_sorted_by_key(Exclusion::path),
+            "`current` must be sorted by path"
+        );
         debug_assert!(previous.is_sorted(), "`previous` must be sorted");
 
         Self {
             added: current
                 .iter()
-                .filter(|path| previous.binary_search(path).is_err())
-                .cloned()
+                .filter(|exclusion| {
+                    previous
+                        .binary_search_by(|path| path.as_path().cmp(exclusion.path()))
+                        .is_err()
+                })
+                .map(|exclusion| exclusion.path().to_path_buf())
                 .collect(),
             removed: previous
                 .iter()
-                .filter(|path| current.binary_search(path).is_err())
+                .filter(|path| {
+                    current
+                        .binary_search_by(|exclusion| exclusion.path().cmp(path))
+                        .is_err()
+                })
                 .cloned()
                 .collect(),
         }

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -9,6 +9,9 @@ pub struct Diff {
 impl Diff {
     /// `current` and `previous` must already be sorted: this uses `binary_search` against them.
     pub fn from_sorted(current: &[PathBuf], previous: &[PathBuf]) -> Self {
+        debug_assert!(current.is_sorted(), "`current` must be sorted");
+        debug_assert!(previous.is_sorted(), "`previous` must be sorted");
+
         Self {
             added: current
                 .iter()

--- a/src/git.rs
+++ b/src/git.rs
@@ -95,7 +95,11 @@ pub fn find_ignored_files(repository_directory: &Path) -> anyhow::Result<Vec<Pat
     }
 
     let absolute_repository_directory = std::path::absolute(repository_directory)?;
-    let canonical_repository_directory = repository_directory.canonicalize()?;
+    let canonical_repository_directory = match repository_directory.canonicalize() {
+        Ok(path) => path,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(vec![]),
+        Err(error) => return Err(error.into()),
+    };
 
     let output = git_command()
         .arg("-C")
@@ -284,6 +288,45 @@ mod tests {
         }
 
         results
+    }
+
+    #[test]
+    fn test_find_ignored_files_of_a_repository_deleted_while_it_is_scanned() {
+        use std::sync::{Arc, atomic::{AtomicBool, Ordering}};
+        use std::time::{Duration, Instant};
+
+        let temp_dir = TempDirectoryBuilder::default().build().unwrap();
+        let repository_path = temp_dir.path().canonicalize().unwrap().join("repository");
+        let stop = Arc::new(AtomicBool::new(false));
+
+        let deleted_path = repository_path.clone();
+        let deleter_stop = stop.clone();
+        let deleter = std::thread::spawn(move || {
+            while !deleter_stop.load(Ordering::Relaxed) {
+                std::fs::create_dir_all(deleted_path.join(".git")).unwrap();
+                let _ = std::fs::remove_dir_all(&deleted_path);
+            }
+        });
+
+        let deadline = Instant::now() + Duration::from_secs(3);
+        let mut errors = 0;
+        for _ in 0..3000 {
+            if Instant::now() >= deadline {
+                break;
+            }
+            if super::find_ignored_files(&repository_path).is_err() {
+                errors += 1;
+            }
+        }
+
+        stop.store(true, Ordering::Relaxed);
+        deleter.join().unwrap();
+
+        assert_eq!(
+            0, errors,
+            "a repository deleted between the existence check and the canonicalization failed \
+             the scan, which stops the monitoring instead of skipping the repository"
+        );
     }
 
     fn run_git(args: &[&str]) {

--- a/src/git.rs
+++ b/src/git.rs
@@ -139,10 +139,22 @@ pub fn find_ignored_files(repository_directory: &Path) -> anyhow::Result<Vec<Pat
 ///
 /// A path that cannot be expressed relative to `repository_directory`, which includes the
 /// repository directory itself, is reported as not ignored.
-pub fn contains_not_ignored_path(
-    repository_directory: &Path,
-    paths: &[&Path],
-) -> anyhow::Result<bool> {
+pub fn contains_not_ignored_path(repository_directory: &Path, paths: &[&Path]) -> bool {
+    match run_check_ignore(repository_directory, paths) {
+        Ok(result) => result,
+        Err(error) => {
+            warn!(
+                "Failed to check the ignored paths of repository '{}': {}",
+                repository_directory.display(),
+                error
+            );
+
+            true
+        }
+    }
+}
+
+fn run_check_ignore(repository_directory: &Path, paths: &[&Path]) -> anyhow::Result<bool> {
     if paths.is_empty() {
         return Ok(false);
     }
@@ -329,7 +341,7 @@ mod tests {
         let paths: Vec<&Path> = ignored_paths.iter().map(PathBuf::as_path).collect();
 
         assert!(
-            !super::contains_not_ignored_path(&repository_path, &paths).unwrap(),
+            !super::contains_not_ignored_path(&repository_path, &paths),
             "every path of the batch is ignored"
         );
 
@@ -338,7 +350,7 @@ mod tests {
         paths.push(&kept_path);
 
         assert!(
-            super::contains_not_ignored_path(&repository_path, &paths).unwrap(),
+            super::contains_not_ignored_path(&repository_path, &paths),
             "one path of the batch is not ignored"
         );
     }

--- a/src/git.rs
+++ b/src/git.rs
@@ -121,6 +121,7 @@ pub fn find_ignored_files(repository_directory: &Path) -> anyhow::Result<Vec<Pat
     Ok(output
         .stdout
         .split(|&b| b == 0)
+        .map(|bytes| bytes.strip_suffix(b"/").unwrap_or(bytes))
         .filter(|s| !s.is_empty())
         .filter_map(|bytes| {
             std::str::from_utf8(bytes)
@@ -461,6 +462,29 @@ mod tests {
             super::find_ignored_files(Path::new("/this/path/does/not/exist"))
                 .unwrap()
                 .is_empty()
+        );
+    }
+
+    #[test]
+    fn test_find_ignored_files_strips_the_trailing_separator_of_a_collapsed_directory() {
+        use std::os::unix::ffi::OsStrExt;
+
+        let temp_dir = TempDirectoryBuilder::default()
+            .add_text_file("repository/.gitignore", "big_dir\n")
+            .add_empty_file("repository/big_dir/a")
+            .build()
+            .unwrap();
+        let repository_path = temp_dir.path().join("repository");
+        crate::commands::tests::init_git_repository(&repository_path);
+
+        let ignored_files = super::find_ignored_files(&repository_path).unwrap();
+
+        assert_eq!(ignored_files, vec![repository_path.join("big_dir")]);
+        assert!(
+            !ignored_files[0].as_os_str().as_bytes().ends_with(b"/"),
+            "git ls-files --directory emits a collapsed directory with a trailing separator: it \
+             must be stripped so the cache holds a single spelling of each path, otherwise every \
+             byte-level lookup has to probe both"
         );
     }
 

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,11 +1,15 @@
 use std::{
     collections::BTreeSet,
     ffi::OsStr,
+    io::Write,
+    os::unix::ffi::OsStrExt,
     path::{Path, PathBuf},
+    process::Stdio,
     sync::Arc,
     thread::JoinHandle,
 };
 
+use anyhow::Context;
 use crossbeam_channel::Receiver;
 use log::warn;
 
@@ -126,6 +130,75 @@ pub fn find_ignored_files(repository_directory: &Path) -> anyhow::Result<Vec<Pat
         .collect())
 }
 
+/// Tell whether at least one of `paths` is not ignored by `repository_directory`.
+///
+/// A path that is ignored cannot change what `find_ignored_files` reports, but a path that is
+/// not ignored can: `git ls-files --directory` stops collapsing a directory as soon as it
+/// contains something that is not ignored, so the exclusion of that directory must be removed.
+///
+/// A path that cannot be expressed relative to `repository_directory`, which includes the
+/// repository directory itself, is reported as not ignored.
+pub fn contains_not_ignored_path(
+    repository_directory: &Path,
+    paths: &[&Path],
+) -> anyhow::Result<bool> {
+    if paths.is_empty() {
+        return Ok(false);
+    }
+
+    let mut input = Vec::new();
+
+    for path in paths {
+        match path.strip_prefix(repository_directory) {
+            Ok(relative_path) if !relative_path.as_os_str().is_empty() => {
+                input.extend_from_slice(relative_path.as_os_str().as_bytes());
+                input.push(0);
+            }
+            _ => return Ok(true),
+        }
+    }
+
+    let mut child = git_command()
+        .arg("-C")
+        .arg(repository_directory)
+        .arg("check-ignore")
+        .arg("--stdin")
+        .arg("-z")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+    let mut child_stdin = child
+        .stdin
+        .take()
+        .context("Failed to open the standard input of git check-ignore")?;
+    // Write from another thread: git flushes the ignored paths as it reads them, so filling the
+    // stdin pipe while nothing drains the stdout pipe deadlocks, both sides blocked in write.
+    // Measured on macOS: 10000 paths (188 KB) completes, 40000 (800 KB) and 200000 (4 MB) hang.
+    let writer_thread = std::thread::spawn(move || child_stdin.write_all(&input));
+    let output = child.wait_with_output()?;
+    let _ = writer_thread.join();
+
+    match output.status.code() {
+        Some(0) => Ok(output
+            .stdout
+            .split(|&byte| byte == 0)
+            .filter(|path| !path.is_empty())
+            .count()
+            < paths.len()),
+        Some(1) => Ok(true),
+        _ => {
+            warn!(
+                "Failed to check the ignored paths of repository '{}': {}",
+                repository_directory.display(),
+                String::from_utf8_lossy(&output.stderr)
+            );
+
+            Ok(true)
+        }
+    }
+}
+
 pub fn find_parent_repository(path: impl AsRef<Path>) -> Option<PathBuf> {
     let mut path = path.as_ref();
 
@@ -236,6 +309,36 @@ mod tests {
             Some(excludes_path),
             result,
             "get_global_git_ignore returned the repository-local core.excludesFile"
+        );
+    }
+
+    #[test]
+    fn test_contains_not_ignored_path_with_a_batch_larger_than_a_pipe_buffer() {
+        let temp_dir = TempDirectoryBuilder::default()
+            .add_text_file("repository/.gitignore", "*.log\n")
+            .build()
+            .unwrap();
+        let repository_path = temp_dir.path().join("repository");
+        run_git(&["init", "-q", repository_path.to_str().unwrap()]);
+
+        let logs_path = repository_path.join("logs");
+        let ignored_paths: Vec<PathBuf> = (0..50_000)
+            .map(|index| logs_path.join(format!("file_{index}.log")))
+            .collect();
+        let paths: Vec<&Path> = ignored_paths.iter().map(PathBuf::as_path).collect();
+
+        assert!(
+            !super::contains_not_ignored_path(&repository_path, &paths).unwrap(),
+            "every path of the batch is ignored"
+        );
+
+        let mut paths = paths;
+        let kept_path = logs_path.join("keep.txt");
+        paths.push(&kept_path);
+
+        assert!(
+            super::contains_not_ignored_path(&repository_path, &paths).unwrap(),
+            "one path of the batch is not ignored"
         );
     }
 

--- a/src/git.rs
+++ b/src/git.rs
@@ -292,7 +292,10 @@ mod tests {
 
     #[test]
     fn test_find_ignored_files_of_a_repository_deleted_while_it_is_scanned() {
-        use std::sync::{Arc, atomic::{AtomicBool, Ordering}};
+        use std::sync::{
+            Arc,
+            atomic::{AtomicBool, Ordering},
+        };
         use std::time::{Duration, Instant};
 
         let temp_dir = TempDirectoryBuilder::default().build().unwrap();

--- a/src/git.rs
+++ b/src/git.rs
@@ -25,45 +25,12 @@ pub fn find_repositories(
     ignored_directories: &BTreeSet<PathBuf>,
     threads: usize,
 ) -> Option<(Receiver<PathBuf>, JoinHandle<()>)> {
-    find_git_entries(directories, ignored_directories, threads, true)
-}
-
-pub fn find_nested_repositories(
-    repository: &Path,
-    ignored_directories: &BTreeSet<PathBuf>,
-    threads: usize,
-) -> anyhow::Result<BTreeSet<PathBuf>> {
-    let directories = BTreeSet::from([repository.to_path_buf()]);
-    let mut nested_repositories = BTreeSet::new();
-
-    if let Some((rx, thread_handle)) =
-        find_git_entries(&directories, ignored_directories, threads, false)
-    {
-        while let Ok(found) = rx.recv() {
-            if found != repository {
-                nested_repositories.insert(found);
-            }
-        }
-        thread_handle
-            .join()
-            .map_err(|_| anyhow::anyhow!("nested repository discovery thread panicked"))?;
-    }
-
-    Ok(nested_repositories)
-}
-
-fn find_git_entries(
-    directories: &BTreeSet<PathBuf>,
-    ignored_directories: &BTreeSet<PathBuf>,
-    threads: usize,
-    respect_gitignore: bool,
-) -> Option<(Receiver<PathBuf>, JoinHandle<()>)> {
     if directories.is_empty() {
         return None;
     }
 
     let ignored_directories = Arc::new(ignored_directories.clone());
-    let walker = create_walk_builder(directories, respect_gitignore)
+    let walker = create_walk_builder(directories, true)
         .threads(threads)
         .build_parallel();
     let (tx, rx) = crossbeam_channel::bounded(128);

--- a/src/git.rs
+++ b/src/git.rs
@@ -25,12 +25,45 @@ pub fn find_repositories(
     ignored_directories: &BTreeSet<PathBuf>,
     threads: usize,
 ) -> Option<(Receiver<PathBuf>, JoinHandle<()>)> {
+    find_git_entries(directories, ignored_directories, threads, true)
+}
+
+pub fn find_nested_repositories(
+    repository: &Path,
+    ignored_directories: &BTreeSet<PathBuf>,
+    threads: usize,
+) -> anyhow::Result<BTreeSet<PathBuf>> {
+    let directories = BTreeSet::from([repository.to_path_buf()]);
+    let mut nested_repositories = BTreeSet::new();
+
+    if let Some((rx, thread_handle)) =
+        find_git_entries(&directories, ignored_directories, threads, false)
+    {
+        while let Ok(found) = rx.recv() {
+            if found != repository {
+                nested_repositories.insert(found);
+            }
+        }
+        thread_handle
+            .join()
+            .map_err(|_| anyhow::anyhow!("nested repository discovery thread panicked"))?;
+    }
+
+    Ok(nested_repositories)
+}
+
+fn find_git_entries(
+    directories: &BTreeSet<PathBuf>,
+    ignored_directories: &BTreeSet<PathBuf>,
+    threads: usize,
+    respect_gitignore: bool,
+) -> Option<(Receiver<PathBuf>, JoinHandle<()>)> {
     if directories.is_empty() {
         return None;
     }
 
     let ignored_directories = Arc::new(ignored_directories.clone());
-    let walker = create_walk_builder(directories, true)
+    let walker = create_walk_builder(directories, respect_gitignore)
         .threads(threads)
         .build_parallel();
     let (tx, rx) = crossbeam_channel::bounded(128);

--- a/src/main.rs
+++ b/src/main.rs
@@ -261,7 +261,7 @@ fn import_legacy_cache_file(
     let legacy_cache: LegacyCache = json::load_json_file(legacy_cache_file_path)?;
     let mut cache = Cache::create(cache_file_path)?;
 
-    cache.reset(legacy_cache.paths)?;
+    cache.reset(legacy_cache.paths.into_iter().map(diff::Exclusion::orphan))?;
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -361,9 +361,6 @@ mod tests {
 
     fn create_repository(root_directory: impl AsRef<Path>) -> TempDirectory {
         let root_directory = root_directory.as_ref();
-        if root_directory.exists() && root_directory.is_dir() {
-            std::fs::remove_dir_all(root_directory).unwrap();
-        }
         let repository_path = root_directory.join("repository");
         let mut config = Config::default();
         config.search_directories.clear();
@@ -385,8 +382,7 @@ mod tests {
 
     #[test]
     fn test_program_run() {
-        let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        let temp_dir_path = root.join("test_program_run");
+        let temp_dir_path = crate::commands::tests::prepare_test_directory("test_program_run");
         let _temp_dir = create_repository(&temp_dir_path);
         let config_file_path = temp_dir_path.join("config.json");
         let cache_file_path = temp_dir_path.join("cache.db");
@@ -432,13 +428,9 @@ mod tests {
     #[test]
     #[serial]
     fn test_program_monitor() {
-        let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        let temp_dir_path = root.join("test_program_monitor");
+        let temp_dir_path = crate::commands::tests::prepare_test_directory("test_program_monitor");
         let _temp_dir = {
             let root_directory = &temp_dir_path;
-            if root_directory.exists() && root_directory.is_dir() {
-                std::fs::remove_dir_all(root_directory).unwrap();
-            }
             let repository_path = root_directory.join("repository");
             let mut config = Config {
                 debounce_duration: Duration::from_secs(1),
@@ -507,13 +499,10 @@ mod tests {
     #[test]
     #[serial]
     fn test_program_monitor_reload_config() {
-        let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        let temp_dir_path = root.join("test_program_monitor_reload_config");
+        let temp_dir_path =
+            crate::commands::tests::prepare_test_directory("test_program_monitor_reload_config");
         let temp_dir = {
             let root_directory = &temp_dir_path;
-            if root_directory.exists() && root_directory.is_dir() {
-                std::fs::remove_dir_all(root_directory).unwrap();
-            }
             let repository_path = root_directory.join("repository");
             let mut config = Config {
                 debounce_duration: Duration::from_secs(1),
@@ -596,13 +585,11 @@ mod tests {
     #[test]
     #[serial]
     fn test_program_monitor_reload_config_error() {
-        let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        let temp_dir_path = root.join("test_program_monitor_reload_config_error");
+        let temp_dir_path = crate::commands::tests::prepare_test_directory(
+            "test_program_monitor_reload_config_error",
+        );
         let _temp_dir = {
             let root_directory = &temp_dir_path;
-            if root_directory.exists() && root_directory.is_dir() {
-                std::fs::remove_dir_all(root_directory).unwrap();
-            }
             let repository_path = root_directory.join("repository");
             let mut config = Config {
                 debounce_duration: Duration::from_secs(1),

--- a/src/main.rs
+++ b/src/main.rs
@@ -380,6 +380,33 @@ mod tests {
         temp_dir
     }
 
+    fn create_monitored_repository(
+        root_directory: impl AsRef<Path>,
+        search_directory: &str,
+    ) -> TempDirectory {
+        let root_directory = root_directory.as_ref();
+        let repository_path = root_directory.join("repository");
+        let mut config = Config {
+            debounce_duration: Duration::from_secs(1),
+            ..Default::default()
+        };
+        config.search_directories.clear();
+        config
+            .search_directories
+            .insert(root_directory.join(search_directory));
+        let temp_dir = TempDirectoryBuilder::default()
+            .root_folder(root_directory)
+            .add_directory("empty_dir")
+            .add_text_file("config.json", serde_json::to_string(&config).unwrap())
+            .add_text_file("repository/.gitignore", "a\nb\n")
+            .build()
+            .unwrap();
+
+        crate::commands::tests::init_git_repository(repository_path);
+
+        temp_dir
+    }
+
     #[test]
     fn test_program_run() {
         let temp_dir_path = crate::commands::tests::prepare_test_directory("test_program_run");
@@ -429,26 +456,7 @@ mod tests {
     #[serial]
     fn test_program_monitor() {
         let temp_dir_path = crate::commands::tests::prepare_test_directory("test_program_monitor");
-        let _temp_dir = {
-            let root_directory = &temp_dir_path;
-            let repository_path = root_directory.join("repository");
-            let mut config = Config {
-                debounce_duration: Duration::from_secs(1),
-                ..Default::default()
-            };
-            config.search_directories.clear();
-            config.search_directories.insert(repository_path.clone());
-            let temp_dir = TempDirectoryBuilder::default()
-                .root_folder(root_directory)
-                .add_text_file("config.json", serde_json::to_string(&config).unwrap())
-                .add_text_file("repository/.gitignore", "a\nb\n")
-                .build()
-                .unwrap();
-
-            crate::commands::tests::init_git_repository(repository_path);
-
-            temp_dir
-        };
+        let _temp_dir = create_monitored_repository(&temp_dir_path, "repository");
         let config_file_path = temp_dir_path.join("config.json");
         let cache_file_path = temp_dir_path.join("cache.db");
         let cli = Cli {
@@ -501,29 +509,7 @@ mod tests {
     fn test_program_monitor_reload_config() {
         let temp_dir_path =
             crate::commands::tests::prepare_test_directory("test_program_monitor_reload_config");
-        let temp_dir = {
-            let root_directory = &temp_dir_path;
-            let repository_path = root_directory.join("repository");
-            let mut config = Config {
-                debounce_duration: Duration::from_secs(1),
-                ..Default::default()
-            };
-            config.search_directories.clear();
-            config
-                .search_directories
-                .insert(root_directory.join("empty_dir"));
-            let temp_dir = TempDirectoryBuilder::default()
-                .root_folder(root_directory)
-                .add_directory("empty_dir")
-                .add_text_file("config.json", serde_json::to_string(&config).unwrap())
-                .add_text_file("repository/.gitignore", "a\nb\n")
-                .build()
-                .unwrap();
-
-            crate::commands::tests::init_git_repository(repository_path);
-
-            temp_dir
-        };
+        let temp_dir = create_monitored_repository(&temp_dir_path, "empty_dir");
         let config_file_path = temp_dir_path.join("config.json");
         let cache_file_path = temp_dir_path.join("cache.db");
         let cli = Cli {
@@ -588,29 +574,7 @@ mod tests {
         let temp_dir_path = crate::commands::tests::prepare_test_directory(
             "test_program_monitor_reload_config_error",
         );
-        let _temp_dir = {
-            let root_directory = &temp_dir_path;
-            let repository_path = root_directory.join("repository");
-            let mut config = Config {
-                debounce_duration: Duration::from_secs(1),
-                ..Default::default()
-            };
-            config.search_directories.clear();
-            config
-                .search_directories
-                .insert(root_directory.join("empty_dir"));
-            let temp_dir = TempDirectoryBuilder::default()
-                .root_folder(root_directory)
-                .add_directory("empty_dir")
-                .add_text_file("config.json", serde_json::to_string(&config).unwrap())
-                .add_text_file("repository/.gitignore", "a\nb\n")
-                .build()
-                .unwrap();
-
-            crate::commands::tests::init_git_repository(repository_path);
-
-            temp_dir
-        };
+        let _temp_dir = create_monitored_repository(&temp_dir_path, "empty_dir");
         let config_file_path = temp_dir_path.join("config.json");
         let cache_file_path = temp_dir_path.join("cache.db");
         let cli = Cli {

--- a/src/main.rs
+++ b/src/main.rs
@@ -380,6 +380,19 @@ mod tests {
         temp_dir
     }
 
+    fn poll_until(timeout: Duration, mut condition: impl FnMut() -> bool) -> bool {
+        let deadline = std::time::Instant::now() + timeout;
+
+        while std::time::Instant::now() < deadline {
+            if condition() {
+                return true;
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+
+        condition()
+    }
+
     fn create_monitored_repository(
         root_directory: impl AsRef<Path>,
         search_directory: &str,
@@ -387,7 +400,7 @@ mod tests {
         let root_directory = root_directory.as_ref();
         let repository_path = root_directory.join("repository");
         let mut config = Config {
-            debounce_duration: Duration::from_secs(1),
+            debounce_duration: Duration::from_millis(100),
             ..Default::default()
         };
         config.search_directories.clear();
@@ -489,9 +502,17 @@ mod tests {
         std::fs::write(&a_file_path, "").unwrap();
         std::fs::write(&b_file_path, "").unwrap();
         std::fs::write(&c_file_path, "").unwrap();
-        std::thread::sleep(Duration::from_secs(5));
+        let excluded = poll_until(Duration::from_secs(10), || {
+            crate::timemachine::tests::is_excluded_from_time_machine(&a_file_path)
+                && crate::timemachine::tests::is_excluded_from_time_machine(&b_file_path)
+        });
         crate::commands::tests::send_sigint();
         handle.join().unwrap();
+
+        assert!(
+            excluded,
+            "the monitor did not exclude the gitignored files it was notified about"
+        );
 
         assert!(crate::timemachine::tests::is_excluded_from_time_machine(
             &a_file_path

--- a/src/sql/v2.sql
+++ b/src/sql/v2.sql
@@ -1,0 +1,21 @@
+-- Record which repository created each exclusion.
+-- The monitor rescans one repository at a time and must diff the exclusions that repository
+-- produces against the exclusions it created, not against every cached path under its directory:
+-- the latter also holds the exclusions of the nested repositories, submodules and worktrees it
+-- contains.
+--
+-- 'repository' is nullable because the rows of the previous schema have no known owner. A full
+-- scan repopulates the whole table, so they disappear at the first run.
+CREATE TABLE paths_with_repository (
+    path BLOB NOT NULL,
+    repository BLOB,
+    PRIMARY KEY (path, repository)
+);
+
+INSERT INTO paths_with_repository (path, repository) SELECT path, NULL FROM paths;
+
+DROP TABLE paths;
+
+ALTER TABLE paths_with_repository RENAME TO paths;
+
+CREATE INDEX idx_paths_repository ON paths(repository);


### PR DESCRIPTION
I was initially working on optimizing the changes introduced when fixing #135 but I got side tracked chasing deadlocks, flakiness and other related issues, so this PR ended up covering more ground than planned:

- Performance: only scan a repository once, compute the ownership check on removal candidates only instead of walking every cached path, and stop rescanning a repository when one of its dirty paths no longer exists. Added performance tests.
- Correctness: store the repository that created each exclusion so ownership is no longer re-derived from the filesystem, drop directory exclusions once a non-ignored file appears in them, keep case-only renames excluded, strip the trailing separator emitted by git ls-files --directory, and distinguish a symlink from its target by (device_id, inode).
- Deadlocks and shutdown: fix the monitor deadlocking on configuration reload under heavy churn, on shutdown with a full event queue, and when setting the debounce duration; close the signals handle on drop so the monitor actually returns; merge pending watcher events so the backlog is bounded by the number of changed paths.
- Robustness: treat a repository deleted mid-scan as having nothing ignored, and report the conservative answer when git check-ignore cannot be spawned, instead of stopping the monitor.
- Tests: fix test_program_monitor flakiness by waiting on watches and exclusions instead of sleeping; add regression tests.
- --details on monitor now shows which paths triggered a scan.