### PR TITLE
CI diagnostics for test_case_only_rename_keeps_the_directory_excluded

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,69 +10,30 @@ env:
 permissions:
   contents: read
 jobs:
-  build:
+  hammer:
     runs-on: "macos-latest"
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-        - rust-target: aarch64-apple-darwin
-          label: aarch64
-        - rust-target: x86_64-apple-darwin
-          label: x86-64
-    timeout-minutes: 10
+    timeout-minutes: 45
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
     - name: Setup Rust
       uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
       with:
         toolchain: stable
-        targets: ${{ matrix.rust-target }}
+        targets: x86_64-apple-darwin
     - name: Rust Cache
       uses: Swatinem/rust-cache@f0d9c3887740aee45f6153b24b3a6b815192ec16 # v2
       with:
         key: build
-    - name: Build
-      run: cargo build --all --verbose --locked --target ${{ matrix.rust-target }}
-    - name: Test
-      env:
-        TMIGNORE_RS_TEST_ITERATIONS: "2"
-      run: cargo test --locked --target ${{ matrix.rust-target }} -- --include-ignored
-
-  clippy:
-    runs-on: "macos-latest"
-    timeout-minutes: 10
-    permissions:
-      contents: read
-      checks: write
-    steps:
-    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-    - name: Setup Rust
-      uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
-      with:
-        toolchain: stable
-        components: clippy
-    - name: Rust Cache
-      uses: Swatinem/rust-cache@f0d9c3887740aee45f6153b24b3a6b815192ec16 # v2
-      with:
-        key: clippy
-    - name: Run clippy
-      uses: auguwu/clippy-action@9817d076b82df0194935be9db6154c56ac07b317 # 1.5.0
-      with:
-        check-args: --all --all-targets --locked
-        args: -D warnings
-        token: ${{ secrets.GITHUB_TOKEN }}
-
-  fmt:
-    runs-on: "macos-latest"
-    timeout-minutes: 10
-    steps:
-    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-    - name: Setup Rust
-      uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
-      with:
-        toolchain: stable
-        components: rustfmt
-        cache: false
-    - name: Run rustfmt
-      run: cargo fmt --all --check
+    - name: Build the tests
+      run: cargo test --locked --target x86_64-apple-darwin --no-run
+    - name: Hammer the monitor tests
+      run: |
+        for i in $(seq 1 60); do
+          echo "::group::iteration $i"
+          if ! cargo test --locked --target x86_64-apple-darwin commands::monitor::tests -- --skip test_config_file_does_not_exist --skip test_initial_scan; then
+            echo "::endgroup::"
+            echo "FAILED at iteration $i"
+            exit 1
+          fi
+          echo "::endgroup::"
+        done

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -111,27 +111,22 @@ fn apply_diff_and_print<TM: TimeMachineTrait>(
 }
 
 fn removals_to_apply(diff: &crate::diff::Diff) -> Vec<&PathBuf> {
-    if diff.added.is_empty() {
+    if diff.added.is_empty() || diff.removed.is_empty() {
         return diff.removed.iter().collect();
     }
 
-    let mut canonical_added: Option<HashSet<PathBuf>> = None;
+    let canonical_added: HashSet<PathBuf> = diff
+        .added
+        .iter()
+        .filter_map(|path| path.canonicalize().ok())
+        .collect();
 
     diff.removed
         .iter()
         .filter(|path| {
-            let Ok(canonical_path) = path.canonicalize() else {
-                return true;
-            };
-
-            let canonical_added = canonical_added.get_or_insert_with(|| {
-                diff.added
-                    .iter()
-                    .filter_map(|added_path| added_path.canonicalize().ok())
-                    .collect()
-            });
-
-            !canonical_added.contains(&canonical_path)
+            !path
+                .canonicalize()
+                .is_ok_and(|canonical_path| canonical_added.contains(&canonical_path))
         })
         .collect()
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -297,10 +297,48 @@ pub(crate) mod tests {
         config
     }
 
+    pub(crate) static SIGINT_LOG: std::sync::Mutex<Vec<(std::time::Instant, String)>> =
+        std::sync::Mutex::new(Vec::new());
+
     pub(crate) fn send_sigint() {
+        if let Ok(mut log) = SIGINT_LOG.lock() {
+            log.push((
+                std::time::Instant::now(),
+                std::thread::current()
+                    .name()
+                    .unwrap_or("<unnamed>")
+                    .to_string(),
+            ));
+        }
+
         unsafe {
             libc::kill(libc::getpid(), signal_hook::consts::SIGINT);
         }
+    }
+
+    pub(crate) fn sigint_log_report(reference: std::time::Instant) -> String {
+        let Ok(log) = SIGINT_LOG.lock() else {
+            return String::from("<poisoned>");
+        };
+
+        let entries: Vec<String> = log
+            .iter()
+            .map(|(instant, thread)| {
+                if *instant >= reference {
+                    format!(
+                        "{thread} +{}ms",
+                        instant.duration_since(reference).as_millis()
+                    )
+                } else {
+                    format!(
+                        "{thread} -{}ms",
+                        reference.duration_since(*instant).as_millis()
+                    )
+                }
+            })
+            .collect();
+
+        format!("{} sigints: [{}]", entries.len(), entries.join(", "))
     }
 
     #[test]

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -46,12 +46,15 @@ fn apply_diff_and_print<TM: TimeMachineTrait>(
 ) -> HashSet<PathBuf> {
     let mut add_failed_paths = HashSet::new();
 
-    // Remove before adding: on a case insensitive filesystem a directory renamed by case only is
-    // removed under its old spelling and added under the new one, and both spellings are the same
-    // item, so adding first would let the removal undo it.
+    // On a case insensitive filesystem a directory renamed by case only is removed under its old
+    // spelling and added under the new one, and both spellings are the same item: excluding and
+    // unexcluding the same item in one pass is not applied in the order the calls are made, so the
+    // removal is dropped instead.
+    let removed = removals_to_apply(diff);
+
     let mut remove_errors = Vec::new();
     if !dry_run {
-        let mut exclusion_errors = TM::remove_exclusions(diff.removed.iter());
+        let mut exclusion_errors = TM::remove_exclusions(removed.iter().copied());
 
         remove_errors.append(&mut exclusion_errors);
     }
@@ -66,7 +69,7 @@ fn apply_diff_and_print<TM: TimeMachineTrait>(
     }
 
     let add_count = diff.added.len().saturating_sub(add_errors.len());
-    let remove_count = diff.removed.len();
+    let remove_count = removed.len();
 
     if add_count > 0 {
         info!(
@@ -95,7 +98,7 @@ fn apply_diff_and_print<TM: TimeMachineTrait>(
     }
 
     if details {
-        for path in &diff.removed {
+        for path in &removed {
             info!("- {}", path.display());
         }
     }
@@ -105,6 +108,32 @@ fn apply_diff_and_print<TM: TimeMachineTrait>(
     }
 
     add_failed_paths
+}
+
+fn removals_to_apply(diff: &crate::diff::Diff) -> Vec<&PathBuf> {
+    if diff.added.is_empty() {
+        return diff.removed.iter().collect();
+    }
+
+    let mut canonical_added: Option<HashSet<PathBuf>> = None;
+
+    diff.removed
+        .iter()
+        .filter(|path| {
+            let Ok(canonical_path) = path.canonicalize() else {
+                return true;
+            };
+
+            let canonical_added = canonical_added.get_or_insert_with(|| {
+                diff.added
+                    .iter()
+                    .filter_map(|added_path| added_path.canonicalize().ok())
+                    .collect()
+            });
+
+            !canonical_added.contains(&canonical_path)
+        })
+        .collect()
 }
 
 fn create_whitelist(whitelist_patterns: &BTreeSet<String>) -> Result<RegexSet, regex::Error> {
@@ -176,6 +205,7 @@ fn join_thread<T>(thread_handle: std::thread::JoinHandle<T>) -> anyhow::Result<T
 #[cfg(test)]
 pub(crate) mod tests {
     use std::{
+        cell::RefCell,
         collections::BTreeSet,
         path::{Path, PathBuf},
         time::Duration,
@@ -333,5 +363,61 @@ pub(crate) mod tests {
             added: BTreeSet::new(),
         };
         let _ = apply_diff_and_print::<MockTimeMachineError>(&diff, false, false);
+    }
+
+    thread_local! {
+        static RECORDED_CALLS: RefCell<Vec<(&'static str, PathBuf)>> = const { RefCell::new(Vec::new()) };
+    }
+
+    struct MockTimeMachineRecorder;
+
+    impl TimeMachineTrait for MockTimeMachineRecorder {
+        fn add_exclusions<'a>(paths: impl Iterator<Item = &'a PathBuf>) -> Vec<Error> {
+            RECORDED_CALLS.with_borrow_mut(|calls| {
+                calls.extend(paths.map(|path| ("add", path.clone())));
+            });
+
+            Vec::new()
+        }
+
+        fn remove_exclusions<'a>(paths: impl Iterator<Item = &'a PathBuf>) -> Vec<Error> {
+            RECORDED_CALLS.with_borrow_mut(|calls| {
+                calls.extend(paths.map(|path| ("remove", path.clone())));
+            });
+
+            Vec::new()
+        }
+    }
+
+    #[test]
+    fn test_apply_diff_does_not_remove_an_item_it_adds_under_another_spelling() {
+        let temp_dir = TempDirectoryBuilder::default()
+            .add_empty_file("foo/a")
+            .build()
+            .unwrap();
+        let lower_case_path = temp_dir.path().join("foo");
+        let upper_case_path = temp_dir.path().join("Foo");
+
+        assert!(
+            upper_case_path.exists(),
+            "this test needs a case insensitive filesystem"
+        );
+
+        let diff = Diff {
+            added: BTreeSet::from([lower_case_path.clone()]),
+            removed: BTreeSet::from([upper_case_path]),
+        };
+
+        RECORDED_CALLS.with_borrow_mut(Vec::clear);
+
+        let error_paths = apply_diff_and_print::<MockTimeMachineRecorder>(&diff, false, false);
+
+        assert!(error_paths.is_empty());
+        assert_eq!(
+            vec![("add", lower_case_path)],
+            RECORDED_CALLS.with_borrow(Clone::clone),
+            "both spellings are the same item, so removing the old one would undo the addition of \
+             the new one"
+        );
     }
 }

--- a/src/commands/monitor.rs
+++ b/src/commands/monitor.rs
@@ -1065,6 +1065,7 @@ mod tests {
     fn test_set_watched_paths_registers_the_watch_before_returning() {
         let temp_dir = TempDirectoryBuilder::default().build().unwrap();
         let temp_dir_path = temp_dir.path().canonicalize().unwrap();
+        let monitor_created_at = Instant::now();
         let mut monitor = super::Monitor::new().unwrap();
 
         monitor.set_debounce_duration(Duration::from_millis(100));
@@ -1089,7 +1090,8 @@ mod tests {
             ),
             other => panic!(
                 "a path created right after set_watched_paths returned was not reported, so the \
-                 watch was not registered yet when it returned: {other:?}"
+                 watch was not registered yet when it returned: {other:?}\n{}",
+                crate::commands::tests::sigint_log_report(monitor_created_at)
             ),
         }
     }

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -161,12 +161,112 @@ pub(crate) mod tests {
 
         super::execute(&config, &mut cache, false, false).unwrap();
 
+        let diagnostics = diagnostics(&repository_path, &upper_case_path, &lower_case_path, &cache);
+
         assert!(
             crate::timemachine::tests::is_excluded_from_time_machine(&lower_case_path),
             "the directory was renamed by case only so it is the same directory, and the \
              filesystem is case insensitive, so removing the old spelling must not undo the \
-             exclusion of the new one"
+             exclusion of the new one\n{diagnostics}"
         );
+    }
+
+    fn diagnostics(
+        repository_path: &std::path::Path,
+        upper_case_path: &std::path::Path,
+        lower_case_path: &std::path::Path,
+        cache: &Cache,
+    ) -> String {
+        use std::fmt::Write;
+
+        let mut report = String::new();
+
+        writeln!(
+            report,
+            "upper case path exists: {}",
+            upper_case_path.exists()
+        )
+        .unwrap();
+        writeln!(
+            report,
+            "lower case path exists: {}",
+            lower_case_path.exists()
+        )
+        .unwrap();
+        writeln!(
+            report,
+            "read_dir: {:?}",
+            std::fs::read_dir(repository_path).map(|entries| entries
+                .filter_map(Result::ok)
+                .map(|entry| entry.file_name())
+                .collect::<Vec<_>>())
+        )
+        .unwrap();
+        writeln!(
+            report,
+            "gitignore: {:?}",
+            std::fs::read_to_string(repository_path.join(".gitignore"))
+        )
+        .unwrap();
+        writeln!(report, "cached paths: {:?}", cache.paths()).unwrap();
+        writeln!(
+            report,
+            "find_ignored_files: {:?}",
+            crate::git::find_ignored_files(repository_path)
+        )
+        .unwrap();
+
+        let ls_files = std::process::Command::new("git")
+            .arg("-C")
+            .arg(repository_path)
+            .arg("ls-files")
+            .arg("--directory")
+            .arg("--exclude-standard")
+            .arg("--ignored")
+            .arg("--others")
+            .output();
+
+        writeln!(report, "{}", describe("git ls-files", ls_files)).unwrap();
+
+        for path in [upper_case_path, lower_case_path] {
+            let xattr = std::process::Command::new("/usr/bin/xattr")
+                .arg("-l")
+                .arg(path)
+                .output();
+
+            writeln!(
+                report,
+                "{}",
+                describe(&format!("xattr {}", path.display()), xattr)
+            )
+            .unwrap();
+
+            let isexcluded = std::process::Command::new("/usr/bin/tmutil")
+                .arg("isexcluded")
+                .arg(path)
+                .output();
+
+            writeln!(
+                report,
+                "{}",
+                describe(&format!("tmutil isexcluded {}", path.display()), isexcluded)
+            )
+            .unwrap();
+        }
+
+        report
+    }
+
+    fn describe(label: &str, result: std::io::Result<std::process::Output>) -> String {
+        match result {
+            Ok(output) => format!(
+                "{label}: status {}, stdout {:?}, stderr {:?}",
+                output.status,
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            ),
+            Err(error) => format!("{label} failed to spawn: {error}"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
Temporary branch: prints the filesystem, git and Time Machine state when the test fails, to see why it only fails on CI. To be ditched.